### PR TITLE
Improve error handling in start.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,3 +108,8 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 - `start.py` importiert interne Module erst nach erfolgreicher Installation der
   Abhängigkeiten. Damit verhindert der Erststart fehlende Pakete wie
   `onnxruntime`.
+
+## [1.4.4] – 2025-07-27
+### Geändert
+- `start.py` haelt das Terminal nun auch bei Fehlern offen und gibt den
+  Stacktrace aus. So koennen Anwender die Fehlermeldung in Ruhe lesen.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ selbstständig klonen, wenn nur diese Datei vorhanden ist.
 Ab Version 1.4.3 werden die internen Module erst nach der Installation der
 Python-Abhängigkeiten importiert. So treten keine Fehler mehr auf, wenn
 Pakete wie `onnxruntime` noch fehlen.
+Ab Version 1.4.4 bleibt das Terminal auch bei Fehlern offen, damit man die
+Ausgabe in Ruhe lesen kann.
 
 ## Automatischer Modell-Download
 

--- a/start.py
+++ b/start.py
@@ -63,7 +63,12 @@ def main() -> None:
     python_bin = venv_path / ("Scripts" if os.name == "nt" else "bin") / "python"
 
     # Repository auf den neuesten Stand bringen, damit requirements aktuell sind
-    run(["git", "pull"])
+    try:
+        run(["git", "pull"])
+    except subprocess.CalledProcessError as exc:
+        # Fehler ausgeben, aber fortfahren. Sonst wuerde sich das Terminal bei
+        # fehlendem Tracking-Branch sofort schliessen.
+        print(f"Git-Pull fehlgeschlagen: {exc}\nBitte Branch-Tracking einrichten.")
 
     # Python-Abhängigkeiten installieren
     run([str(python_bin), "-m", "pip", "install", "-r", "requirements.txt"])
@@ -107,4 +112,14 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception as exc:  # noqa: BLE001
+        # Fehlermeldung ausgeben und auf Eingabe warten, damit das Terminal
+        # geoeffnet bleibt und der Nutzer den Fehler sehen kann.
+        import traceback
+
+        print(f"Fehler: {exc}")
+        traceback.print_exc()
+        input("Zum Beenden Enter druecken...")
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- keep terminal window open even when `start.py` hits an error
- document the new behaviour in the README
- record the change in the CHANGELOG

## Testing
- `pytest -q` *(fails: Could not find pytest-cov)*

------
https://chatgpt.com/codex/tasks/task_e_6877f02e696c8327a497124ca23e5369