### PR TITLE
Fix torch version for Python 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,3 +127,9 @@ Alle Änderungen werden in diesem Dokument festgehalten.
   automatisch `git pull` aus.
 ### Geändert
 - README entsprechend angepasst.
+
+## [1.4.7] – 2025-07-30
+### Geändert
+- `requirements.txt` setzt nun `torch` auf Version 2.2.x, da 2.1.x keine
+  Python‑3.12-Builds bietet.
+- README entsprechend angepasst.

--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ Alle Modelle brauchen eine GPU, bei CPU-Fallback entsteht nur ein leeres Bild.
 
 Das LaMa-Modell wird nun über das PyPI-Paket `iopaint[lama]` bereitgestellt.
 Wir nutzen dabei fest die Version **1.2.5**, um Kompatibilitätsprobleme zu vermeiden.
-Ebenfalls beschränken wir **PyTorch** auf die Version *2.1.x*, da neuere Releases
-mitunter nicht mit `diffusers` oder `iopaint` harmonieren.
+Ab Version 1.4.7 setzen wir **PyTorch** auf die Version *2.2.x*. Die vorherige
+Beschränkung auf *2.1.x* verursachte Installationsprobleme unter Python 3.12.
 
 ![Einstellungen Dialog](gui_screenshot.png "GUI-Einstellungen f\xFCr Inpainting")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ gitpython
 virtualenv
 onnxruntime>=1.17
 numpy
-torch>=2.1,<2.2  # Begrenzung auf stabile 2.1er Version
+torch>=2.2,<2.3  # Ab 1.4.7: Kompatibel mit Python 3.12
 opencv-python
 pillow
 tqdm

--- a/tests/test_batch_runner.py
+++ b/tests/test_batch_runner.py
@@ -32,6 +32,8 @@ import tests.requests_stub as requests_stub
 sys.modules['requests'] = requests_stub
 import tests.huggingface_hub as hf_stub
 sys.modules['huggingface_hub'] = hf_stub
+import tests.loguru as loguru_stub
+sys.modules['loguru'] = loguru_stub
 sys.modules['tqdm'] = importlib.import_module('tests.tqdm')
 sys.modules['segment_anything'] = importlib.import_module('tests.segment_anything')
 

--- a/tests/test_censor_detector.py
+++ b/tests/test_censor_detector.py
@@ -15,6 +15,8 @@ sys.modules['requests'] = requests_stub
 import tests.huggingface_hub as hf_stub
 sys.modules['huggingface_hub'] = hf_stub
 sys.modules['tqdm'] = __import__('tests.tqdm', fromlist=[''])
+import tests.loguru as loguru_stub
+sys.modules['loguru'] = loguru_stub
 
 sys.modules['onnxruntime'] = __import__('onnxruntime') if 'onnxruntime' in sys.modules else sys.modules.get('onnxruntime')
 # ensure stubs for offline


### PR DESCRIPTION
## Zusammenfassung
- Torch-Abhängigkeit auf 2.2.x angehoben
- README und CHANGELOG aktualisiert
- Tests an fehlende `loguru`-Stubs angepasst

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6877f5142b248327afb3271649f12280