### PR TITLE
Fix diffusers conflict for iopaint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,3 +139,9 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 - `iopaint[lama]` ist nun auf Version 1.6.0 angehoben, um Python 3.12 zu
   unterstützen.
 - README entsprechend angepasst.
+
+## [1.4.9] – 2025-07-31
+### Geändert
+- `diffusers` ist nun auf Version 0.27.2 festgeschrieben, da iopaint 1.6.0
+  diese Version benötigt.
+- README entsprechend ergänzt.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ Alle Modelle brauchen eine GPU, bei CPU-Fallback entsteht nur ein leeres Bild.
 
 Das LaMa-Modell wird nun über das PyPI-Paket `iopaint[lama]` bereitgestellt.
 Seit Version **1.4.8** setzen wir dabei auf **iopaint 1.6.0**, da ältere Versionen
-kein Python 3.12 unterstützen.
+kein Python 3.12 unterstützen. Ab Version **1.4.9** ist deshalb
+`diffusers` auf **0.27.2** festgeschrieben, weil diese Version von iopaint
+benötigt wird.
 Ab Version 1.4.7 setzen wir **PyTorch** auf die Version *2.2.x*. Die vorherige
 Beschränkung auf *2.1.x* verursachte Installationsprobleme unter Python 3.12.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,8 @@ flask
 requests
 aiohttp
 segment-anything @ git+https://github.com/facebookresearch/segment-anything.git
-diffusers>=0.28
 iopaint[lama]==1.6.0
+diffusers==0.27.2
 rich>=13.6
 loguru>=0.7
 pytest>=8.0


### PR DESCRIPTION
## Summary
- pin `diffusers` to 0.27.2 so it matches iopaint 1.6.0
- document the change in README and CHANGELOG

## Testing
- `PYTHONPATH=tests pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f89d36dc8327945412de8d35c353