### PR TITLE
Fix venv execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,3 +151,10 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 - `start.py` prüft nun, ob `npm` installiert ist und gibt einen klaren
   Fehlerhinweis aus.
 - README erwähnt die notwendige Node.js-Installation.
+
+## [1.4.11] – 2025-08-02
+### Geändert
+- `start.py` startet nach dem Anlegen der virtuellen Umgebung automatisch
+  erneut mit dem Python der venv. Dadurch stehen neu installierte Pakete sofort
+  zur Verfügung.
+- README erläutert dieses Verhalten.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ Python-Abhängigkeiten importiert. So treten keine Fehler mehr auf, wenn
 Pakete wie `onnxruntime` noch fehlen.
 Ab Version 1.4.4 bleibt das Terminal auch bei Fehlern offen, damit man die
 Ausgabe in Ruhe lesen kann.
+Ab Version 1.4.6 startet `start.py` nach dem Anlegen der virtuellen Umgebung
+automatisch erneut mit dem Python der venv. Dadurch sind frisch installierte
+Pakete sofort nutzbar und Importfehler werden vermieden.
 
 ## Automatischer Modell-Download
 

--- a/start.py
+++ b/start.py
@@ -90,6 +90,12 @@ def main() -> None:
     # Pfad zum Python-Interpreter der venv ermitteln
     python_bin = venv_path / ("Scripts" if os.name == "nt" else "bin") / "python"
 
+    # Wenn dieses Skript nicht mit dem venv-Python ausgeführt wird,
+    # starten wir uns selbst erneut. So stehen die installierten Pakete
+    # unmittelbar zur Verfügung und es kommt zu keinen Importfehlern.
+    if Path(sys.executable).resolve() != python_bin.resolve():
+        os.execv(str(python_bin), [str(python_bin), __file__] + sys.argv[1:])
+
     # Repository pruefen und aktualisieren
     update_repo()
     check_npm()


### PR DESCRIPTION
## Summary
- starte `start.py` automatisch innerhalb der virtuellen Umgebung
- erwähne das Verhalten in README und CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877fcd66d3c8327bcabeb5294092791