### PR TITLE
fix: Hinweis bei fehlendem rich

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,3 +182,8 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 - `start.py` importiert `rich` nun erst in der Hilfsfunktion `run`. Dadurch
   startet das Skript auch dann fehlerfrei, wenn die Abhängigkeiten noch nicht
   installiert sind.
+
+## [1.4.16] – 2025-08-05
+### Geändert
+- Fehlt das Paket `rich`, gibt `start.py` nun einen Hinweis aus und führt den
+  Befehl ohne Fortschrittsanzeige aus.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Repository vorliegen. Ist dies der Fall, wird ein Hinweis angezeigt und der
 automatische `git pull` übersprungen.
 Ab Version 1.4.14 zeigt `start.py` bei jedem externen Befehl eine kleine Fortschrittsspinne im Terminal, damit man den aktuellen Schritt erkennt.
 Ab Version 1.4.15 kann das Skript auch ohne das Paket `rich` starten. Die Fortschrittsanzeige erscheint erst, wenn die Abhängigkeit installiert ist.
+Ab Version 1.4.16 weist `start.py` darauf hin, wenn `rich` fehlt und arbeitet dann ohne Fortschrittsanzeige weiter.
 
 ## Automatischer Modell-Download
 

--- a/start.py
+++ b/start.py
@@ -25,6 +25,10 @@ def run(cmd: list[str], *, beschreibung: str | None = None, **kwargs) -> None:
         try:
             from rich.progress import Progress, SpinnerColumn, TextColumn
         except ImportError:
+            # Hinweis ausgeben, falls die Bibliothek fehlt
+            print(
+                "[Info] Paket 'rich' nicht gefunden - Befehle laufen ohne Fortschrittsanzeige."
+            )
             # Fallback ohne Fortschrittsanzeige
             subprocess.run(cmd, check=True, **kwargs)
             return


### PR DESCRIPTION
## Zusammenfassung
- gebe einen Hinweis aus, wenn `rich` nicht installiert ist
- dokumentiere das Verhalten im README
- ergänze das CHANGELOG um die neue Version

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878063f22248327a35e7409b0f1b61a