### PR TITLE
Implement generate_report helper script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,3 +187,8 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 ### Geändert
 - Fehlt das Paket `rich`, gibt `start.py` nun einen Hinweis aus und führt den
   Befehl ohne Fortschrittsanzeige aus.
+
+## [1.4.17] – 2025-08-06
+### Hinzugefügt
+- Neues Skript `generate_report.py`, das die CLI `python -m core.report` aufruft
+  und einen Zielpfad für den Report entgegen nimmt.

--- a/README.md
+++ b/README.md
@@ -198,6 +198,12 @@ Einen Report kann man auch nachträglich erstellen:
 python -m core.report Projekte/Manga03.dezproj <batch_id>
 ```
 
+Alternativ erlaubt das Skript `generate_report.py` einen frei wählbaren Zielpfad:
+
+```bash
+python generate_report.py Projekte/Manga03.dezproj <batch_id> --report Auswertung/report.json
+```
+
 Beispiel für einen JSON-Eintrag:
 
 ```json

--- a/generate_report.py
+++ b/generate_report.py
@@ -1,0 +1,38 @@
+"""Hilfsskript zum Erzeugen eines Batch-Reports.
+
+Dieses Skript ruft intern die CLI `python -m core.report` auf und
+speichert den erzeugten Report an einem frei wählbaren Pfad.
+"""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Report erzeugen")
+    parser.add_argument("project", help="Pfad zur .dezproj-Datei")
+    parser.add_argument("batch_id", help="ID des Batch-Laufs")
+    parser.add_argument(
+        "--report",
+        required=True,
+        type=Path,
+        help="Zielpfad f\xFCr den Report",
+    )
+    args = parser.parse_args()
+
+    # CLI ausf\xfchren und Pfad zum erzeugten Report erhalten
+    result = subprocess.check_output(
+        [sys.executable, "-m", "core.report", args.project, args.batch_id],
+        text=True,
+    ).strip()
+
+    src = Path(result)
+    args.report.parent.mkdir(parents=True, exist_ok=True)
+    src.replace(args.report)
+    print(args.report)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_generate_report_script.py
+++ b/tests/test_generate_report_script.py
@@ -1,0 +1,41 @@
+"""Testet das Skript generate_report.py."""
+
+import json
+import subprocess
+import sys
+import os
+from pathlib import Path
+
+from core.logger_setup import init_logging
+
+
+def test_generate_report_creates_file(tmp_path: Path) -> None:
+    proj_file = tmp_path / "proj.dezproj"
+    proj_file.write_text("{}")
+
+    logger = init_logging(tmp_path)
+    logger.info("start")
+
+    log_file = next((tmp_path / "logs").glob("run_*.jsonl"))
+    batch_id = log_file.stem.replace("run_", "")
+    logger.bind(img="a", model="lama").info("done", duration_ms=500)
+
+    out_file = tmp_path / "report.json"
+    env = os.environ.copy()
+    test_path = Path(__file__).resolve().parent
+    env["PYTHONPATH"] = os.pathsep.join([str(test_path), env.get("PYTHONPATH", "")])
+    subprocess.check_call(
+        [
+            sys.executable,
+            str(Path(__file__).resolve().parents[1] / "generate_report.py"),
+            str(proj_file),
+            batch_id,
+            "--report",
+            str(out_file),
+        ],
+        env=env,
+    )
+
+    assert out_file.exists()
+    data = json.loads(out_file.read_text())
+    assert data["batch_id"] == batch_id


### PR DESCRIPTION
## Summary
- add `generate_report.py` to wrap the `core.report` CLI
- document the new helper script
- update CHANGELOG
- test that the script creates a report

## Testing
- `PYTHONPATH=tests pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878076b43fc8327aece9702ab7106f0