### PR TITLE
Fix restart loop in start.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,3 +192,9 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 ### Hinzugefügt
 - Neues Skript `generate_report.py`, das die CLI `python -m core.report` aufruft
   und einen Zielpfad für den Report entgegen nimmt.
+
+## [1.4.18] – 2025-08-06
+### Behoben
+- `start.py` konnte in seltenen Fällen unendlich viele Python-Prozesse starten,
+  wenn der Wechsel in die virtuelle Umgebung scheiterte. Eine Umgebungsvariable
+  verhindert nun diese Neustart-Schleife.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ automatische `git pull` übersprungen.
 Ab Version 1.4.14 zeigt `start.py` bei jedem externen Befehl eine kleine Fortschrittsspinne im Terminal, damit man den aktuellen Schritt erkennt.
 Ab Version 1.4.15 kann das Skript auch ohne das Paket `rich` starten. Die Fortschrittsanzeige erscheint erst, wenn die Abhängigkeit installiert ist.
 Ab Version 1.4.16 weist `start.py` darauf hin, wenn `rich` fehlt und arbeitet dann ohne Fortschrittsanzeige weiter.
+Ab Version 1.4.18 verhindert eine Umgebungsvariable endlose Neustart-Schleifen, wenn das Skript die virtuelle Umgebung aktiviert.
 
 ## Automatischer Modell-Download
 

--- a/start.py
+++ b/start.py
@@ -160,12 +160,15 @@ def main() -> None:
     python_bin = venv_path / ("Scripts" if os.name == "nt" else "bin") / "python"
 
     # Wenn dieses Skript nicht mit dem venv-Python ausgeführt wird,
-    # starten wir uns selbst erneut. Unter Windows führt ein
-    # ``os.execv`` jedoch gelegentlich zu ``OSError: [Errno 12] Not enough space``.
-    # Daher erzeugen wir dort einen neuen Prozess und beenden uns.
-    if Path(sys.executable).resolve() != python_bin.resolve():
+    # starten wir uns selbst erneut. Um eine Neustart-Schleife zu vermeiden,
+    # setzen wir eine Umgebungsvariable.
+    if (
+        Path(sys.executable).resolve() != python_bin.resolve()
+        and not os.environ.get("DEZENSUR_VENV")
+    ):
+        os.environ["DEZENSUR_VENV"] = "1"
         if os.name == "nt":
-            subprocess.check_call([str(python_bin), __file__] + sys.argv[1:])
+            subprocess.check_call([str(python_bin), __file__] + sys.argv[1:], env=os.environ)
             sys.exit(0)
         else:
             os.execv(str(python_bin), [str(python_bin), __file__] + sys.argv[1:])


### PR DESCRIPTION
## Summary
- avoid endless restart loops when switching to venv by using an env var
- document behaviour in README
- add changelog entry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68780ddb4b608327a6325ef46cf4e653