### PR TITLE
Fix npm check message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,3 +198,8 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 - `start.py` konnte in seltenen Fällen unendlich viele Python-Prozesse starten,
   wenn der Wechsel in die virtuelle Umgebung scheiterte. Eine Umgebungsvariable
   verhindert nun diese Neustart-Schleife.
+
+## [1.4.19] – 2025-08-07
+### Geändert
+- `start.py` gibt nun auch im Terminal einen Hinweis aus, wenn `npm` fehlt. So
+  ist der Grund eines Abbruchs besser erkennbar.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Ab Version 1.4.14 zeigt `start.py` bei jedem externen Befehl eine kleine Fortsch
 Ab Version 1.4.15 kann das Skript auch ohne das Paket `rich` starten. Die Fortschrittsanzeige erscheint erst, wenn die Abhängigkeit installiert ist.
 Ab Version 1.4.16 weist `start.py` darauf hin, wenn `rich` fehlt und arbeitet dann ohne Fortschrittsanzeige weiter.
 Ab Version 1.4.18 verhindert eine Umgebungsvariable endlose Neustart-Schleifen, wenn das Skript die virtuelle Umgebung aktiviert.
+Ab Version 1.4.19 erscheint der Hinweis auf fehlendes `npm` nun auch im Terminal.
 
 ## Automatischer Modell-Download
 

--- a/start.py
+++ b/start.py
@@ -98,11 +98,11 @@ def update_repo() -> None:
 def check_npm() -> None:
     """Prueft, ob npm verfuegbar ist."""
     if shutil.which("npm") is None:
+        msg = "Node.js bzw. npm wurde nicht gefunden. Bitte erst installieren."
+        # Hinweis auch im Terminal ausgeben
+        print(msg)
         tk.Tk().withdraw()
-        messagebox.showerror(
-            "Fehler",
-            "Node.js bzw. npm wurde nicht gefunden. Bitte erst installieren."
-        )
+        messagebox.showerror("Fehler", msg)
         sys.exit(1)
 
 def ensure_repo() -> None:

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -1,0 +1,16 @@
+import importlib
+from unittest import mock
+import pytest
+
+start = importlib.import_module('start')
+
+
+def test_check_npm_missing(capsys):
+    with mock.patch('shutil.which', return_value=None), \
+         mock.patch('tkinter.Tk'), \
+         mock.patch('tkinter.messagebox.showerror') as m_err, \
+         pytest.raises(SystemExit):
+        start.check_npm()
+    out = capsys.readouterr().out
+    assert "Node.js bzw. npm wurde nicht gefunden" in out
+    m_err.assert_called_once()


### PR DESCRIPTION
## Summary
- print Fehlermeldung bei fehlendem npm auch im Terminal
- changelog und README ergaenzt
- Test fuer `check_npm` hinzugefuegt

## Testing
- `pytest -ra`

------
https://chatgpt.com/codex/tasks/task_e_68781053c908832782b11235ceacabf1