### PR TITLE
Fix fallback for hf_hub_download progress_bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,3 +203,10 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 ### Geändert
 - `start.py` gibt nun auch im Terminal einen Hinweis aus, wenn `npm` fehlt. So
   ist der Grund eines Abbruchs besser erkennbar.
+
+## [1.4.20] – 2025-08-08
+### Behoben
+- Kompatibilitätsproblem mit älteren ``huggingface_hub``-Versionen: Das
+  ``progress_bar``-Argument wird nun optional behandelt.
+### Geändert
+- README um Hinweis zur geänderten Downloadfunktion ergänzt.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Ab Version 1.4.19 erscheint der Hinweis auf fehlendes `npm` nun auch im Terminal
 Fehlende KI-Modelle werden beim Start automatisch aus dem Hugging-Face-Hub
 heruntergeladen und im Ordner `models/` gespeichert. Eine SHA‑256-Prüfung
 stellt sicher, dass die Dateien korrekt übertragen wurden.
+Seit Version 1.4.20 ignoriert der Download das optionale ``progress_bar``-
+Argument, sodass auch ältere ``huggingface_hub``-Versionen funktionieren.
 
 ## Automatische Zensur-Erkennung (Modul 3)
 

--- a/core/dep_manager.py
+++ b/core/dep_manager.py
@@ -142,13 +142,23 @@ def download_model(name: str, progress: bool = True) -> Path:
     if size > 500 * 1024 * 1024:
         _parallel_download(url, dest, size, progress)
     else:
-        path = hf_hub_download(
-            repo_id=repo,
-            filename=filename,
-            cache_dir=models_dir,
-            resume_download=True,
-            progress_bar=False,
-        )
+        try:
+            path = hf_hub_download(
+                repo_id=repo,
+                filename=filename,
+                cache_dir=models_dir,
+                resume_download=True,
+                progress_bar=False,
+            )
+        except TypeError:
+            # Ältere huggingface_hub-Versionen kennen das Argument
+            # ``progress_bar`` nicht.
+            path = hf_hub_download(
+                repo_id=repo,
+                filename=filename,
+                cache_dir=models_dir,
+                resume_download=True,
+            )
         shutil.copy(Path(path), dest)
 
     sha256 = info.get("sha256")


### PR DESCRIPTION
## Summary
- handle older `huggingface_hub` versions that don't accept `progress_bar`
- document download compatibility in README
- update changelog

## Testing
- `PYTHONPATH=tests pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_68781307cce88327b735ffbf4c3dbd62