### PR TITLE
fix: verbessere Modell-Download bei 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,3 +217,10 @@ Alle Änderungen werden in diesem Dokument festgehalten.
   ursprüngliche Modellname nicht verfügbar ist.
 ### Geändert
 - README weist auf diese Fallback-Strategie hin.
+
+## [1.4.22] – 2025-08-10
+### Behoben
+- Fehlende Modelle werden nun über einen Repository-Snapshot gesucht, wenn alle
+  bekannten Dateinamen einen 404-Fehler liefern.
+### Geändert
+- README erläutert den neuen Snapshot-Fallback.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ Seit Version 1.4.20 ignoriert der Download das optionale ``progress_bar``-
 Argument, sodass auch ältere ``huggingface_hub``-Versionen funktionieren.
 Ab Version 1.4.21 prüft der Dependency-Manager zudem alternative Dateinamen,
 falls ein Modell auf Hugging Face umbenannt wurde.
+Ab Version 1.4.22 wird bei fehlenden Dateien das gesamte Repository als
+Snapshot heruntergeladen und die erste gefundene ``.onnx``-Datei verwendet.
 
 ## Automatische Zensur-Erkennung (Modul 3)
 

--- a/tests/huggingface_hub.py
+++ b/tests/huggingface_hub.py
@@ -5,3 +5,7 @@ def hf_hub_download(*args, **kwargs):
 
 def hf_hub_url(*args, **kwargs):
     return 'http://example.com/dummy'
+
+
+def snapshot_download(*args, **kwargs):
+    return '/tmp/snapshot'


### PR DESCRIPTION
## Zusammenfassung
- verbessere den Fallback im `dep_manager` durch Repo-Snapshot
- ergänze Alternativnamen für das Anime-Modell
- dokumentiere den Snapshot-Fallback in README und CHANGELOG
- erweitere den Test-Stub von `huggingface_hub`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687815e1bfbc8327a5ecf708b675b994