### PR TITLE
Fix HQ-SAM filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,3 +247,10 @@ Alle Änderungen werden in diesem Dokument festgehalten.
   erhalten.
 ### Geändert
 - README vermerkt den neuen Modellpfad.
+
+## [1.4.26] – 2025-08-14
+### Behoben
+- Das HQ-SAM-Modell nutzt nun die Datei ``model.safetensors``. ``sam_hq_vit_b.pth``
+  und ``sam_vit_hq.pth`` bleiben als Fallback erhalten.
+### Geändert
+- README weist auf den neuen Dateinamen hin.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Ab Version 1.4.24 kann optional ein Zugangstoken
 über die Umgebungsvariable ``HUGGINGFACE_HUB_TOKEN`` gesetzt werden,
 um private oder nur für angemeldete Nutzer freigegebene Modelle herunterladen zu können.
 Seit Version 1.4.25 wird das HQ-SAM-Modell aus dem Repository `syscv-community/sam-hq-vit-base` geladen. Der frühere Dateiname `sam_vit_hq.pth` bleibt als Fallback erhalten.
+Ab Version 1.4.26 heißt die bereitgestellte Gewichtsdatei `model.safetensors`. Die alten Dateinamen werden weiterhin als Ersatz akzeptiert.
 
 ## Automatische Zensur-Erkennung (Modul 3)
 

--- a/core/dep_manager.py
+++ b/core/dep_manager.py
@@ -31,10 +31,11 @@ MODEL_REGISTRY: dict[str, dict[str, str | list[str] | None]] = {
         "device": "cpu",
     },
     "sam_vit_hq": {
-        # Repository wurde verschoben und der Dateiname geändert
+        # Repository wurde verschoben und die bereitgestellten Gewichte liegen
+        # inzwischen als ``model.safetensors`` vor
         "repo": "syscv-community/sam-hq-vit-base",
-        "filename": "sam_hq_vit_b.pth",
-        "alternatives": ["sam_vit_hq.pth"],
+        "filename": "model.safetensors",
+        "alternatives": ["sam_hq_vit_b.pth", "sam_vit_hq.pth"],
         "sha256": None,
         "device": "gpu",
     },

--- a/tests/test_dep_manager.py
+++ b/tests/test_dep_manager.py
@@ -62,7 +62,7 @@ def test_ensure_model_returns_path(monkeypatch, tmp_path: Path) -> None:
     """Stellt sicher, dass ein Modellpfad geliefert wird."""
 
     def fake_download(*a, **k):
-        dest = tmp_path / "cache" / "sam_hq_vit_b.pth"
+        dest = tmp_path / "cache" / "model.safetensors"
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_text("data")
         return str(dest)


### PR DESCRIPTION
## Summary
- update HQ-SAM registry entry to use `model.safetensors`
- adjust test to expect new filename
- document the new filename in README and CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68781ce1d5a4832798594ad62d034042