### PR TITLE
Fix Censor-Detection model path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,3 +254,11 @@ Alle Änderungen werden in diesem Dokument festgehalten.
   und ``sam_vit_hq.pth`` bleiben als Fallback erhalten.
 ### Geändert
 - README weist auf den neuen Dateinamen hin.
+
+## [1.4.27] – 2025-08-15
+### Geändert
+- ``dep_manager.download_model`` ermittelt nun automatisch den neuesten
+  Unterordner von ``anime_censor_detection``. Dadurch funktionieren zukünftige
+  Versionen ohne Codeanpassung.
+### Hinzugefügt
+- Stub ``list_repo_files`` und aktualisierte Tests.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ Ab Version 1.4.24 kann optional ein Zugangstoken
 um private oder nur für angemeldete Nutzer freigegebene Modelle herunterladen zu können.
 Seit Version 1.4.25 wird das HQ-SAM-Modell aus dem Repository `syscv-community/sam-hq-vit-base` geladen. Der frühere Dateiname `sam_vit_hq.pth` bleibt als Fallback erhalten.
 Ab Version 1.4.26 heißt die bereitgestellte Gewichtsdatei `model.safetensors`. Die alten Dateinamen werden weiterhin als Ersatz akzeptiert.
+Seit Version 1.4.27 erkennt der Downloader automatisch den neuesten Unterordner
+von `anime_censor_detection` (z.B. `censor_detect_v0.9_s/model.onnx`). Damit
+funktioniert der Download auch bei zukünftigen Updates ohne Anpassungen.
 
 ## Automatische Zensur-Erkennung (Modul 3)
 

--- a/tests/huggingface_hub.py
+++ b/tests/huggingface_hub.py
@@ -9,3 +9,7 @@ def hf_hub_url(*args, **kwargs):
 
 def snapshot_download(*args, **kwargs):
     return '/tmp/snapshot'
+
+
+def list_repo_files(*args, **kwargs):
+    return []

--- a/tests/test_censor_detector.py
+++ b/tests/test_censor_detector.py
@@ -44,7 +44,9 @@ def test_cli(tmp_path: Path) -> None:
     Image.new("RGB", (10, 10)).save(img)
     models_dir = Path("models/anime_censor_detection")
     models_dir.mkdir(parents=True, exist_ok=True)
-    (models_dir / "censor_detect_v0.7_s.onnx").write_text("x")
+    subdir = models_dir / "censor_detect_v0.9_s"
+    subdir.mkdir(parents=True, exist_ok=True)
+    (subdir / "model.onnx").write_text("x")
     env = os.environ.copy()
     test_path = Path(__file__).resolve().parent
     env["PYTHONPATH"] = os.pathsep.join([str(test_path), env.get("PYTHONPATH", "")])


### PR DESCRIPTION
## Summary
- passe Modell-Registry an neues Verzeichnislayout an
- Downloader sucht nun automatisch nach dem neuesten Unterordner für das `anime_censor_detection`-Modell
- aktualisiere den huggingface_hub-Stub
- passe Tests an
- erweitere README und CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68781f310a2083279ba3278a10f8415c