### PR TITLE
feat: prüfe Node-Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,3 +262,10 @@ Alle Änderungen werden in diesem Dokument festgehalten.
   Versionen ohne Codeanpassung.
 ### Hinzugefügt
 - Stub ``list_repo_files`` und aktualisierte Tests.
+
+## [1.4.28] – 2025-08-16
+### Hinzugefügt
+- ``start.py`` prüft jetzt die installierte Node-Version und bricht bei Version
+  unter 18 mit einer Fehlermeldung ab.
+### Geändert
+- README erwähnt die Mindestanforderung für Node.js.

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ DeZensur/
 
 ## Schnellstart
 
-Voraussetzung ist eine installierte **Node.js**-Umgebung (inkl. `npm`),
-da die GUI auf Electron basiert.
+Voraussetzung ist eine installierte **Node.js**-Umgebung (inkl. `npm`)
+ab Version **18**, da die GUI auf Electron basiert.
 
 ```bash
 # 1. Repo klonen (alternativ nur start.py herunterladen)
@@ -131,6 +131,8 @@ Ab Version 1.4.26 heißt die bereitgestellte Gewichtsdatei `model.safetensors`. 
 Seit Version 1.4.27 erkennt der Downloader automatisch den neuesten Unterordner
 von `anime_censor_detection` (z.B. `censor_detect_v0.9_s/model.onnx`). Damit
 funktioniert der Download auch bei zukünftigen Updates ohne Anpassungen.
+Ab Version 1.4.28 prüft `start.py` die installierte Node-Version und verlangt
+mindestens Version 18.
 
 ## Automatische Zensur-Erkennung (Modul 3)
 

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -2,15 +2,42 @@ import importlib
 from unittest import mock
 import pytest
 
-start = importlib.import_module('start')
+start = importlib.import_module("start")
 
 
 def test_check_npm_missing(capsys):
-    with mock.patch('shutil.which', return_value=None), \
-         mock.patch('tkinter.Tk'), \
-         mock.patch('tkinter.messagebox.showerror') as m_err, \
-         pytest.raises(SystemExit):
+    with mock.patch("shutil.which", return_value=None), mock.patch(
+        "tkinter.Tk"
+    ), mock.patch("tkinter.messagebox.showerror") as m_err, pytest.raises(SystemExit):
         start.check_npm()
     out = capsys.readouterr().out
     assert "Node.js bzw. npm wurde nicht gefunden" in out
     m_err.assert_called_once()
+
+
+def test_check_npm_outdated(capsys):
+    """Prüft, ob eine zu alte Node-Version bemängelt wird."""
+
+    fake_proc = mock.Mock(returncode=0, stdout="v16.0.0")
+    with mock.patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"), mock.patch(
+        "subprocess.run", return_value=fake_proc
+    ), mock.patch("tkinter.Tk"), mock.patch(
+        "tkinter.messagebox.showerror"
+    ) as m_err, pytest.raises(
+        SystemExit
+    ):
+        start.check_npm()
+    out = capsys.readouterr().out
+    assert "zu alt" in out
+    m_err.assert_called_once()
+
+
+def test_check_npm_ok():
+    """Stellt sicher, dass gültige Versionen akzeptiert werden."""
+
+    fake_proc = mock.Mock(returncode=0, stdout="v18.5.0")
+    with mock.patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"), mock.patch(
+        "subprocess.run", return_value=fake_proc
+    ), mock.patch("tkinter.Tk"), mock.patch("tkinter.messagebox.showerror") as m_err:
+        start.check_npm()
+    m_err.assert_not_called()


### PR DESCRIPTION
## Summary
- überprüfe mit `start.py`, ob Node.js >=18 installiert ist
- erweitere Tests zum neuen Versionscheck
- README und CHANGELOG dokumentieren die Mindestanforderung

## Testing
- `PYTHONPATH=tests pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878208f427c832784cfe622de172b1d