### PR TITLE
Fix npm install by updating electron-reload version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,3 +281,10 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 - ``start.py`` erkennt ``npm`` jetzt auch über die Umgebungsvariable ``NPM_PATH``.
 ### Geändert
 - README beschreibt die neue Variable zum Setzen des ``npm``-Pfads.
+
+## [1.4.31] – 2025-08-19
+### Behoben
+- ``electron-reload`` wird nun in Version ``2.0.2`` installiert, da ``2.0.0`` nicht
+  mehr verfügbar ist.
+### Geändert
+- README verweist auf die aktualisierte Abhängigkeit.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Ab Version 1.4.28 prüft `start.py` die installierte Node-Version und verlangt
 mindestens Version 18.
 Ab Version 1.4.30 kann der Pfad zu `npm` über die Umgebungsvariable
 ``NPM_PATH`` gesetzt werden, falls das Programm nicht im ``PATH`` liegt.
+Ab Version 1.4.31 nutzt die GUI `electron-reload` in Version 2.0.2, weil die zuvor
+eingesetzte Version 2.0.0 nicht mehr verfügbar ist.
 
 ## Automatische Zensur-Erkennung (Modul 3)
 

--- a/gui/package.json
+++ b/gui/package.json
@@ -27,7 +27,7 @@
     "react-dropzone": "^14.0.0",
     "react-router-dom": "^6.0.0",
     "concurrently": "^8.0.0",
-    "electron-reload": "^2.0.0",
+    "electron-reload": "^2.0.2",
     "konva": "^9.3.0",
     "react-konva": "^19.0.24",
     "jest": "^29.0.0",


### PR DESCRIPTION
## Summary
- use electron-reload 2.0.2 in GUI
- document the new dependency in README
- add changelog entry for version 1.4.31

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687886bd5e2c8327b111914058d5ae93