### PR TITLE
Fix npm failure hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -295,3 +295,10 @@ Alle Änderungen werden in diesem Dokument festgehalten.
   zurückgesetzt.
 ### Geändert
 - README entsprechend angepasst.
+
+## [1.4.33] – 2025-08-21
+### Geändert
+- `start.py` gibt nun einen Hinweis aus, wenn `npm install` wegen fehlender
+  Pakete wie `electron-reload` scheitert.
+### Geändert
+- README um diese Info erweitert.

--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ Ab Version 1.4.30 kann der Pfad zu `npm` über die Umgebungsvariable
 ``NPM_PATH`` gesetzt werden, falls das Programm nicht im ``PATH`` liegt.
 Ab Version 1.4.31 setzt die GUI `electron-reload` wieder in Version 2.0.0 ein,
 da sich Version 2.0.2 nicht installieren ließ.
+Ab Version 1.4.33 weist `start.py` auf fehlgeschlagene `npm install`-Befehle hin,
+falls beispielsweise `electron-reload` in der geforderten Version nicht
+gefunden wird.
 
 ## Automatische Zensur-Erkennung (Modul 3)
 

--- a/start.py
+++ b/start.py
@@ -248,7 +248,16 @@ def main() -> None:
             and package_json.stat().st_mtime > node_modules.stat().st_mtime
         )
     ):
-        run([npm_cmd, "install"], cwd="gui", beschreibung="npm install")
+        try:
+            # npm-Abhängigkeiten installieren
+            run([npm_cmd, "install"], cwd="gui", beschreibung="npm install")
+        except subprocess.CalledProcessError:
+            # Hinweis für den Nutzer, falls ein Paket wie electron-reload nicht verfügbar ist
+            print(
+                "npm install schlug fehl. Bitte Prüfe die Internetverbindung "
+                "oder passe die Version von electron-reload im package.json an."
+            )
+            raise
 
     if "--dev" in sys.argv:
         run([npm_cmd, "run", "dev"], cwd="gui", beschreibung="npm run dev")


### PR DESCRIPTION
## Summary
- inform users when `npm install` fails so they can fix `electron-reload`
- document the new behaviour
- add changelog entry

## Testing
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68788b591b288327bd5a362e5b258d4b