### PR TITLE
Fix electron reload version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -302,3 +302,10 @@ Alle Änderungen werden in diesem Dokument festgehalten.
   Pakete wie `electron-reload` scheitert.
 ### Geändert
 - README um diese Info erweitert.
+
+## [1.4.34] – 2025-08-22
+### Geändert
+- `electron-reload` wird jetzt in Version ``2.0.1`` installiert, da 2.0.0 und
+  2.0.2 zu Problemen führten.
+### Geändert
+- README entsprechend angepasst.

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Ab Version 1.4.30 kann der Pfad zu `npm` über die Umgebungsvariable
 ``NPM_PATH`` gesetzt werden, falls das Programm nicht im ``PATH`` liegt.
 Ab Version 1.4.31 setzt die GUI `electron-reload` wieder in Version 2.0.0 ein,
 da sich Version 2.0.2 nicht installieren ließ.
+Ab Version 1.4.34 verwendet die GUI nun `electron-reload` in Version 2.0.1,
+da auch 2.0.0 vereinzelt Probleme bereitete.
 Ab Version 1.4.33 weist `start.py` auf fehlgeschlagene `npm install`-Befehle hin,
 falls beispielsweise `electron-reload` in der geforderten Version nicht
 gefunden wird.

--- a/gui/package.json
+++ b/gui/package.json
@@ -27,7 +27,7 @@
     "react-dropzone": "^14.0.0",
     "react-router-dom": "^6.0.0",
     "concurrently": "^8.0.0",
-    "electron-reload": "^2.0.0",
+    "electron-reload": "^2.0.1",
     "konva": "^9.3.0",
     "react-konva": "^19.0.24",
     "jest": "^29.0.0",


### PR DESCRIPTION
## Zusammenfassung
- setze `electron-reload` auf Version 2.0.1
- Dokumentation und Changelog angepasst

## Tests
- `pytest -qq`

------
https://chatgpt.com/codex/tasks/task_e_68788e3ae5ac8327b708fc4d6a32ec1f