### PR TITLE
Option zum Überspringen von npm install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -316,3 +316,10 @@ Alle Änderungen werden in diesem Dokument festgehalten.
   Das Paket wird daher wieder in Version ``2.0.0`` verwendet.
 ### Geändert
 - README und ``package.json`` entsprechend angepasst.
+
+## [1.4.36] – 2025-08-24
+### Hinzugefügt
+- ``start.py`` bietet mit ``SKIP_NPM_INSTALL`` bzw. ``--skip-npm`` die Möglichkeit,
+  den `npm install`-Schritt zu überspringen.
+### Geändert
+- README beschreibt die neue Option.

--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ nutzt Version 1.4.35 wieder `electron-reload` 2.0.0.
 Ab Version 1.4.33 weist `start.py` auf fehlgeschlagene `npm install`-Befehle hin,
 falls beispielsweise `electron-reload` in der geforderten Version nicht
 gefunden wird.
+Ab Version 1.4.36 kann der Schritt `npm install` mit der Umgebungsvariable
+`SKIP_NPM_INSTALL` oder dem Parameter `--skip-npm` übersprungen werden. Das ist
+hilfreich, wenn die Pakete bereits installiert sind oder keine
+Internetverbindung besteht.
 
 ## Automatische Zensur-Erkennung (Modul 3)
 

--- a/start.py
+++ b/start.py
@@ -236,8 +236,12 @@ def main() -> None:
     package_json = Path("gui/package.json")
     node_modules = Path("gui/node_modules")
 
-    # NPM-Pakete installieren, falls noetig
-    if (
+    # Installation der NPM-Pakete kann über die Umgebungsvariable
+    # "SKIP_NPM_INSTALL" oder den Parameter "--skip-npm" übersprungen werden.
+    skip_npm = os.environ.get("SKIP_NPM_INSTALL") or "--skip-npm" in sys.argv
+
+    # NPM-Pakete installieren, falls erforderlich und nicht übersprungen
+    if not skip_npm and (
         not node_modules.exists()
         or (
             pkg_lock.exists()
@@ -258,6 +262,8 @@ def main() -> None:
                 "oder passe die Version von electron-reload im package.json an."
             )
             raise
+    elif skip_npm:
+        print("npm install wird aufgrund von SKIP_NPM_INSTALL übersprungen.")
 
     if "--dev" in sys.argv:
         run([npm_cmd, "run", "dev"], cwd="gui", beschreibung="npm run dev")


### PR DESCRIPTION
## Zusammenfassung
- Ergänzung in `start.py`: npm-Installation kann über `SKIP_NPM_INSTALL` oder `--skip-npm` ausgelassen werden
- README und CHANGELOG um die neue Option erweitert

## Testanweisungen
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687894143aac8327ad18f54d4fb3f4b6