### PR TITLE
fix: use available electron-reload version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -336,3 +336,9 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 - `electron-reload` 2.0.2 ist aus der Registry verschwunden. Die GUI nutzt wieder die stabile Version 1.6.0.
 ### Geändert
 - README und `package.json` entsprechend angepasst.
+
+## [1.4.39] – 2025-08-27
+### Behoben
+- Version 1.6.0 von `electron-reload` ist im npm-Registry nicht vorhanden. Wir verwenden nun Version 1.5.0.
+### Geändert
+- README und `package.json` wurden entsprechend angepasst.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ Ab Version 1.4.34 sollte die GUI eigentlich `electron-reload` in Version 2.0.1
 einsetzen. Da diese Version jedoch nicht in der Registry vorhanden war,
 nutzte Version 1.4.35 weiterhin `electron-reload` 2.0.0.
 Seit Version 1.4.37 wurde `electron-reload` in Version 2.0.2 verwendet, da 2.0.0 nicht mehr verfügbar war.
-Seit Version 1.4.38 kommt nun wieder die stabile Version 1.6.0 zum Einsatz, weil 2.0.2 aus der Registry entfernt wurde.
+Seit Version 1.4.38 kam kurzzeitig wieder die stabile Version 1.6.0 zum Einsatz, weil 2.0.2 aus der Registry entfernt wurde.
+Seit Version 1.4.39 verwenden wir nun Version 1.5.0, da die zuvor angegebene 1.6.0 nicht im npm-Registry existiert.
 Ab Version 1.4.33 weist `start.py` auf fehlgeschlagene `npm install`-Befehle hin,
 falls beispielsweise `electron-reload` in der geforderten Version nicht
 gefunden wird.

--- a/gui/package.json
+++ b/gui/package.json
@@ -27,7 +27,7 @@
     "react-dropzone": "^14.0.0",
     "react-router-dom": "^6.0.0",
     "concurrently": "^8.0.0",
-    "electron-reload": "1.6.0",
+    "electron-reload": "^1.5.0",
     "konva": "^9.3.0",
     "react-konva": "^19.0.24",
     "jest": "^29.0.0",


### PR DESCRIPTION
## Summary
- set `electron-reload` to `^1.5.0`
- document new version in README
- note change in CHANGELOG

## Testing
- `PYTHONPATH=tests pytest -q`
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878a0e384e48327b625ea51671c73ec