### PR TITLE
Fix Electron preload module load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -349,3 +349,9 @@ Alle Änderungen werden in diesem Dokument festgehalten.
   Jetzt verwenden wir Version 19.0.7 und passen `konva` auf 9.3.3 an.
 ### Geändert
 - README und `package.json` führen die korrigierte Version auf.
+
+## [1.4.41] – 2025-08-29
+### Behoben
+- `preload.js` verwendet jetzt CommonJS, damit Electron das Skript korrekt lädt.
+### Geändert
+- README erwähnt das CommonJS-Format des Preload-Skripts.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ DeZensur/
 
 Voraussetzung ist eine installierte **Node.js**-Umgebung (inkl. `npm`)
 ab Version **18**, da die GUI auf Electron basiert.
+Beachte: Das Preload-Skript `gui/electron/preload.js` muss im CommonJS-Stil 
+(`require` statt `import`) vorliegen, da Electron ES-Module dort nicht lädt.
 
 ```bash
 # 1. Repo klonen (alternativ nur start.py herunterladen)

--- a/gui/electron/preload.js
+++ b/gui/electron/preload.js
@@ -1,5 +1,5 @@
 // Bindet IPC-Funktionen für das Renderer-Frontend ein
-import { contextBridge, ipcRenderer } from 'electron';
+const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('api', {
   openFileDialog: () => ipcRenderer.invoke('dialog:openFile'),


### PR DESCRIPTION
## Summary
- use CommonJS in the preload script so Electron can load it
- document the preload requirement in the README
- note the change in the CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878aa3a38cc83279f8b629ae1c5a76a