### PR TITLE
Fix Electron security warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -355,3 +355,9 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 - `preload.js` verwendet jetzt CommonJS, damit Electron das Skript korrekt lädt.
 ### Geändert
 - README erwähnt das CommonJS-Format des Preload-Skripts.
+
+## [1.4.42] – 2025-08-30
+### Geändert
+- `index.html` definiert nun eine Content-Security-Policy, wodurch die Electron-Warnung zu unsicheren Skripten verschwindet.
+### Geändert
+- README weist auf die neue Content-Security-Policy hin.

--- a/README.md
+++ b/README.md
@@ -66,8 +66,10 @@ DeZensur/
 
 Voraussetzung ist eine installierte **Node.js**-Umgebung (inkl. `npm`)
 ab Version **18**, da die GUI auf Electron basiert.
-Beachte: Das Preload-Skript `gui/electron/preload.js` muss im CommonJS-Stil 
+Ab Version 1.4.41 muss das Preload-Skript `gui/electron/preload.js` im CommonJS-Stil
 (`require` statt `import`) vorliegen, da Electron ES-Module dort nicht lädt.
+Seit Version 1.4.42 besitzt `gui/index.html` eine eigene Content-Security-Policy,
+welche die Electron-Warnung zu unsicheren Skripten unterbindet.
 
 ```bash
 # 1. Repo klonen (alternativ nur start.py herunterladen)

--- a/gui/electron/main.js
+++ b/gui/electron/main.js
@@ -11,11 +11,23 @@ function createWindow() {
   mainWindow = new BrowserWindow({
     width: 1200,
     height: 800,
-    webPreferences: {
-      preload: path.join(__dirname, 'preload.js'),
-      contextIsolation: true,
-    },
-  });
+      webPreferences: {
+        preload: path.join(__dirname, 'preload.js'),
+        contextIsolation: true,
+      },
+    });
+
+    // Content-Security-Policy für das Renderer-Fenster setzen
+    const csp =
+      "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' http://127.0.0.1:8787 http://localhost:5173";
+    mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
+      callback({
+        responseHeaders: {
+          ...details.responseHeaders,
+          'Content-Security-Policy': [csp],
+        },
+      });
+    });
 
   // Backend-Server bei Bedarf starten
   if (!isServerRunning()) {

--- a/gui/index.html
+++ b/gui/index.html
@@ -4,6 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>DeZensur</title>
+    <!-- Content-Security-Policy verhindert unsichere Skriptausführung -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' http://127.0.0.1:8787 http://localhost:5173"
+    />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- set Content Security Policy in the Electron renderer via `onHeadersReceived`
- add CSP meta tag to `index.html`
- document the new security policy in README and CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878ac9f042883278e5fe9ea7519ed14