### PR TITLE
Add npm audit step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -361,3 +361,9 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 - `index.html` definiert nun eine Content-Security-Policy, wodurch die Electron-Warnung zu unsicheren Skripten verschwindet.
 ### Geändert
 - README weist auf die neue Content-Security-Policy hin.
+
+## [1.4.43] – 2025-08-31
+### Hinzugefügt
+- `start.py` ruft nach einem erfolgreichen `npm install` automatisch `npm audit` auf und meldet eventuelle Probleme.
+### Geändert
+- README beschreibt die neue Sicherheitsprüfung.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ hilfreich, wenn die Pakete bereits installiert sind oder keine
 Internetverbindung besteht.
 Ab Version 1.4.40 setzt die GUI `react-konva` in Version 19.0.7 ein,
 da die zuvor eingetragene Version 19.0.24 nie veröffentlicht wurde.
+Ab Version 1.4.43 führt `start.py` nach einem erfolgreichen `npm install`
+automatisch `npm audit` aus und weist bei Fehlern auf mögliche
+Sicherheitslücken hin.
 
 ## Automatische Zensur-Erkennung (Modul 3)
 

--- a/start.py
+++ b/start.py
@@ -139,6 +139,17 @@ def check_npm() -> None:
         pass
 
 
+def run_npm_audit() -> None:
+    """Führt `npm audit` aus und weist bei Fehlern darauf hin."""
+
+    try:
+        run([npm_cmd, "audit"], cwd="gui", beschreibung="npm audit")
+    except subprocess.CalledProcessError:
+        print(
+            "npm audit schlug fehl. Bitte ggf. manuell mit Internetverbindung ausführen."
+        )
+
+
 def ensure_repo() -> None:
     """Klonen des Git-Repositories, falls die Dateien fehlen."""
 
@@ -255,6 +266,8 @@ def main() -> None:
         try:
             # npm-Abhängigkeiten installieren
             run([npm_cmd, "install"], cwd="gui", beschreibung="npm install")
+            # Nach erfolgreicher Installation Sicherheitsprüfung ausführen
+            run_npm_audit()
         except subprocess.CalledProcessError:
             # Hinweis für den Nutzer, falls ein Paket wie electron-reload nicht verfügbar ist
             print(


### PR DESCRIPTION
## Summary
- run `npm audit` after installing GUI packages
- document new security check in README
- log update in CHANGELOG

## Testing
- `PYTHONPATH=tests pytest -q`
- `npm audit` *(fails: ENOLOCK)*

------
https://chatgpt.com/codex/tasks/task_e_6878af718cf4832787172572aaf57822