### PR TITLE
Fix blank GUI by adjusting Vite base path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -367,3 +367,9 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 - `start.py` ruft nach einem erfolgreichen `npm install` automatisch `npm audit` auf und meldet eventuelle Probleme.
 ### Geändert
 - README beschreibt die neue Sicherheitsprüfung.
+
+## [1.4.44] – 2025-09-01
+### Behoben
+- `vite.config.js` setzt nun den Basis-Pfad auf `./`, damit die gebaute GUI ihre Assets korrekt findet.
+### Geändert
+- README weist auf die neue `base`-Einstellung hin.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ da die zuvor eingetragene Version 19.0.24 nie veröffentlicht wurde.
 Ab Version 1.4.43 führt `start.py` nach einem erfolgreichen `npm install`
 automatisch `npm audit` aus und weist bei Fehlern auf mögliche
 Sicherheitslücken hin.
+Ab Version 1.4.44 verwendet die Vite-Konfiguration den relativen Basis-Pfad
+`./`, damit die gebaute Electron-Oberfläche ihre Assets findet.
 
 ## Automatische Zensur-Erkennung (Modul 3)
 

--- a/gui/vite.config.js
+++ b/gui/vite.config.js
@@ -5,6 +5,8 @@ import path from 'path';
 export default defineConfig({
   plugins: [react()],
   root: '.',
+  // Basis-Pfad relativ setzen, damit Electron die gebauten Assets findet
+  base: './',
   build: {
     outDir: 'dist',
     emptyOutDir: true,


### PR DESCRIPTION
## Summary
- set base path to `./` in `vite.config.js` so packaged Electron builds load correctly
- document Vite base path note in README
- add changelog entry for version 1.4.44

## Testing
- `PYTHONPATH=tests pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878b25a96948327aa26d2929239f3b4