### PR TITLE
Git-Update beim Start prüfen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -373,3 +373,8 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 - `vite.config.js` setzt nun den Basis-Pfad auf `./`, damit die gebaute GUI ihre Assets korrekt findet.
 ### Geändert
 - README weist auf die neue `base`-Einstellung hin.
+
+## [1.4.45] – 2025-09-02
+### Geändert
+- `start.py` prüft das Git-Repository nun direkt beim Start und führt ggf. ein Update durch, bevor weitere Schritte erfolgen.
+- README beschreibt diese Änderung.

--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ automatisch `npm audit` aus und weist bei Fehlern auf mögliche
 Sicherheitslücken hin.
 Ab Version 1.4.44 verwendet die Vite-Konfiguration den relativen Basis-Pfad
 `./`, damit die gebaute Electron-Oberfläche ihre Assets findet.
+Ab Version 1.4.45 prüft `start.py` das Git-Repository bereits vor dem Anlegen der
+virtuellen Umgebung und aktualisiert es gegebenenfalls.
 
 ## Automatische Zensur-Erkennung (Modul 3)
 

--- a/start.py
+++ b/start.py
@@ -64,11 +64,17 @@ def ensure_clean_worktree() -> bool:
         print(f"Git-Status konnte nicht abgefragt werden: {exc}")
         return True
     if status:
-        tk.Tk().withdraw()
-        messagebox.showwarning(
-            "Uncommittete Änderungen",
-            "Bitte committe oder stash deine Änderungen, bevor ein Pull erfolgt.",
-        )
+        try:
+            tk.Tk().withdraw()
+            messagebox.showwarning(
+                "Uncommittete Änderungen",
+                "Bitte committe oder stash deine Änderungen, bevor ein Pull erfolgt.",
+            )
+        except tk.TclError:
+            # Fallback, falls keine GUI verfügbar ist
+            print(
+                "Uncommittete Änderungen gefunden. Bitte committe oder stash sie, bevor ein Pull erfolgt."
+            )
         return False
     return True
 
@@ -184,6 +190,8 @@ def ensure_repo() -> None:
 
 # Erst sicherstellen, dass das Repo vorhanden ist
 ensure_repo()
+# Vor allen weiteren Schritten prüfen wir, ob das Git-Repository aktuell ist
+update_repo()
 
 # Projektverzeichnis dem Modulpfad hinzufügen
 if str(project_root) not in sys.path:
@@ -219,8 +227,7 @@ def main() -> None:
         else:
             os.execv(str(python_bin), [str(python_bin), __file__] + sys.argv[1:])
 
-    # Repository pruefen und aktualisieren
-    update_repo()
+    # npm und Node-Version pruefen
     check_npm()
 
     # Python-Abhängigkeiten installieren


### PR DESCRIPTION
## Zusammenfassung
- `start.py` prüft nun direkt nach dem Start, ob das Git-Repository aktuell ist
- Warnhinweis bei uncommitteten Änderungen funktioniert jetzt auch ohne Display
- README und CHANGELOG um die neue Funktion ergänzt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878b6ba5e588327b99a8c294a9ab188