### PR TITLE
Fix: GUI-Build automatisch ausführen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -384,3 +384,7 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 - Option `--auto-stash` in `start.py`, die ungesicherte Änderungen automatisch vor dem `git pull` stasht und anschließend wieder einspielt.
 ### Geändert
 - README erläutert die neue Option.
+
+## [1.4.47] – 2025-09-04
+### Behoben
+- `start.py` baut die GUI nun automatisch, wenn `gui/dist` fehlt. Dadurch wird die Oberfläche korrekt angezeigt.

--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ Ab Version 1.4.44 verwendet die Vite-Konfiguration den relativen Basis-Pfad
 `./`, damit die gebaute Electron-Oberfläche ihre Assets findet.
 Ab Version 1.4.45 prüft `start.py` das Git-Repository bereits vor dem Anlegen der
 virtuellen Umgebung und aktualisiert es gegebenenfalls.
+Ab Version 1.4.47 wird die React-Oberfläche automatisch gebaut, wenn noch kein
+`gui/dist`-Ordner existiert. Dadurch erscheint die GUI auch bei einer frischen
+Installation korrekt.
 
 ## Automatische Zensur-Erkennung (Modul 3)
 

--- a/start.py
+++ b/start.py
@@ -5,13 +5,13 @@ herunterladen und danach wie gewohnt starten.
 """
 
 import os
+import shutil
 import subprocess
 import sys
+import time
 import tkinter as tk
 from pathlib import Path
 from tkinter import messagebox
-import shutil
-import time
 
 # Pfad zum npm-Binary; wird in check_npm ermittelt
 npm_cmd = "npm"
@@ -124,9 +124,15 @@ def update_repo(*, auto_stash: bool = False) -> None:
     finally:
         if stashed:
             try:
-                run(["git", "stash", "pop"], cwd=project_root, beschreibung="git stash pop")
+                run(
+                    ["git", "stash", "pop"],
+                    cwd=project_root,
+                    beschreibung="git stash pop",
+                )
             except subprocess.CalledProcessError:
-                print("Stash konnte nicht angewendet werden. Bitte manuell 'git stash pop' ausführen.")
+                print(
+                    "Stash konnte nicht angewendet werden. Bitte manuell 'git stash pop' ausführen."
+                )
 
 
 def check_npm() -> None:
@@ -179,6 +185,14 @@ def run_npm_audit() -> None:
         print(
             "npm audit schlug fehl. Bitte ggf. manuell mit Internetverbindung ausführen."
         )
+
+
+def ensure_gui_build() -> None:
+    """Baut das Frontend, falls noch keine Dist-Dateien vorhanden sind."""
+
+    dist_index = project_root / "gui" / "dist" / "index.html"
+    if not dist_index.exists():
+        run([npm_cmd, "run", "build"], cwd="gui", beschreibung="npm run build")
 
 
 def ensure_repo() -> None:
@@ -266,8 +280,8 @@ def main() -> None:
     )
 
     # Erst nach der Installation können wir die Module importieren
-    from core.dep_manager import ensure_model
     from core import censor_detector
+    from core.dep_manager import ensure_model
 
     try:
         ensure_model("anime_censor_detection")
@@ -317,6 +331,8 @@ def main() -> None:
     if "--dev" in sys.argv:
         run([npm_cmd, "run", "dev"], cwd="gui", beschreibung="npm run dev")
     else:
+        # Falls die gebaute Oberflaeche fehlt, wird sie nun erzeugt
+        ensure_gui_build()
         run([npm_cmd, "start"], cwd="gui", beschreibung="npm start")
 
 

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -1,5 +1,6 @@
 import importlib
 from unittest import mock
+
 import pytest
 
 start = importlib.import_module("start")
@@ -57,3 +58,26 @@ def test_ensure_clean_worktree_autostash():
     )
     assert sauber is True
     assert stashed is True
+
+
+def test_ensure_gui_build(monkeypatch, tmp_path):
+    """Stellt sicher, dass die GUI bei fehlendem Build erzeugt wird."""
+
+    monkeypatch.setattr(start, "project_root", tmp_path)
+    (tmp_path / "gui").mkdir()
+
+    with mock.patch.object(start, "run") as m_run:
+        start.ensure_gui_build()
+        m_run.assert_called_once_with(
+            [start.npm_cmd, "run", "build"],
+            cwd="gui",
+            beschreibung="npm run build",
+        )
+
+    dist = tmp_path / "gui" / "dist"
+    dist.mkdir(parents=True)
+    (dist / "index.html").write_text("x")
+
+    with mock.patch.object(start, "run") as m_run:
+        start.ensure_gui_build()
+        m_run.assert_not_called()


### PR DESCRIPTION
## Zusammenfassung
- baue die React-Oberfläche automatisch, wenn `gui/dist` noch fehlt
- teste `ensure_gui_build`
- dokumentiere das Verhalten in README und CHANGELOG

## Testing
- `isort start.py tests/test_start.py`
- `black start.py tests/test_start.py`
- `pytest -q -rA`

------
https://chatgpt.com/codex/tasks/task_e_6878bbb6d2fc832783143a5c8eee9368