### PR TITLE
Fix Windows build error by disabling code signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -388,3 +388,9 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 ## [1.4.47] – 2025-09-04
 ### Behoben
 - `start.py` baut die GUI nun automatisch, wenn `gui/dist` fehlt. Dadurch wird die Oberfläche korrekt angezeigt.
+
+## [1.4.48] – 2025-09-05
+### Behoben
+- Unter Windows schlug der Electron-Build fehl, wenn keine Symlink-Rechte vorhanden waren. `start.py` setzt nun `CSC_IDENTITY_AUTO_DISCOVERY=false`, damit kein Codesigning stattfindet.
+### Geändert
+- README beschreibt diese neue Umgebungsvariable.

--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ virtuellen Umgebung und aktualisiert es gegebenenfalls.
 Ab Version 1.4.47 wird die React-Oberfläche automatisch gebaut, wenn noch kein
 `gui/dist`-Ordner existiert. Dadurch erscheint die GUI auch bei einer frischen
 Installation korrekt.
+Ab Version 1.4.48 setzt `start.py` unter Windows automatisch
+`CSC_IDENTITY_AUTO_DISCOVERY=false`, damit `electron-builder`
+ohne Symlink-Rechte funktioniert.
 
 ## Automatische Zensur-Erkennung (Modul 3)
 

--- a/start.py
+++ b/start.py
@@ -192,7 +192,19 @@ def ensure_gui_build() -> None:
 
     dist_index = project_root / "gui" / "dist" / "index.html"
     if not dist_index.exists():
-        run([npm_cmd, "run", "build"], cwd="gui", beschreibung="npm run build")
+        # Unter Windows kann das Electron-Build scheitern, wenn keine
+        # Berechtigung zum Anlegen von Symlinks vorhanden ist. Durch Setzen
+        # dieser Umgebungsvariable wird das Codesigning deaktiviert und der
+        # entsprechende Download entfaellt.
+        env = os.environ.copy()
+        if os.name == "nt":
+            env.setdefault("CSC_IDENTITY_AUTO_DISCOVERY", "false")
+        run(
+            [npm_cmd, "run", "build"],
+            cwd="gui",
+            beschreibung="npm run build",
+            env=env,
+        )
 
 
 def ensure_repo() -> None:

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -72,6 +72,7 @@ def test_ensure_gui_build(monkeypatch, tmp_path):
             [start.npm_cmd, "run", "build"],
             cwd="gui",
             beschreibung="npm run build",
+            env=mock.ANY,
         )
 
     dist = tmp_path / "gui" / "dist"


### PR DESCRIPTION
## Summary
- disable code signing in `ensure_gui_build` to avoid symlink errors on Windows
- adjust unit test
- document environment variable in README
- update CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878c09656348327b9dcb695a8ac979f