### PR TITLE
Fix addImages without open project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -410,3 +410,10 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 ### Geändert
 - README erklärt den Unterschied zwischen `npm run dev` und `npm start`.
 
+## [1.4.51] – 2025-09-08
+### Behoben
+- "Bilder hinzufügen" löst jetzt einen Hinweis aus, wenn noch kein Projekt
+  geöffnet ist. Dadurch verhindert die GUI einen Absturz.
+### Geändert
+- README um Hinweis auf die neue Fehlermeldung ergänzt.
+

--- a/README.md
+++ b/README.md
@@ -297,6 +297,8 @@ Die GUI erlaubt das Importieren einzelner Bilder oder ganzer Ordner. Alle
 Bilder werden in `originals/` kopiert und in der Galerie als Thumbnails
 angezeigt. Einstellungen und Bildstatus werden in einer `.dezproj`-Datei im
 Projektordner gespeichert.
+Versucht man, ohne geöffnetes Projekt Bilder hinzuzufügen, erscheint nun eine
+Hinweismeldung.
 
 ---
 

--- a/gui/src/components/ProjectMenu.jsx
+++ b/gui/src/components/ProjectMenu.jsx
@@ -19,6 +19,11 @@ export default function ProjectMenu() {
     const files = await window.api.openFileDialog();
     if (files && files.length) {
       const data = await window.api.project.addImages(files);
+      // Falls kein Projekt offen ist, liefert der IPC-Handler null
+      if (!data) {
+        alert('Bitte erst ein Projekt anlegen oder öffnen.');
+        return;
+      }
       const imgs = data.images.map((img) => ({
         id: img.id,
         path: 'file://' + folderPath(data, img.file),


### PR DESCRIPTION
## Summary
- check for existing project before adding images
- document new message in README and CHANGELOG

## Testing
- `pytest -q`
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878c9bd30388327ab990d7feae23bce