### PR TITLE
Add basic desktop layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -417,3 +417,9 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 ### Geändert
 - README um Hinweis auf die neue Fehlermeldung ergänzt.
 
+## [1.5.0] – 2025-09-09
+### Hinzugefügt
+- Neues Desktop-Layout in der React-GUI mit Titelleiste,
+  Befehlsleiste und Seitenleisten.
+- Tailwind-Konfiguration enthält nun Farbtokens für das Dark-Theme.
+

--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ Ab Version 1.4.48 setzt `start.py` unter Windows automatisch
 ohne Symlink-Rechte funktioniert.
 Ab Version 1.4.49 fordert `start.py` bei fehlenden Symlink-Rechten
 automatisch Administratorrechte an und startet sich neu.
+Ab Version 1.5.0 verpasst die GUI ein neues Desktop-Layout mit Titelleiste,
+Befehlsleiste, Seitenleisten und Arbeitsbereich.
 
 ## Automatische Zensur-Erkennung (Modul 3)
 

--- a/gui/src/App.jsx
+++ b/gui/src/App.jsx
@@ -1,17 +1,27 @@
 // Hauptkomponente der React-Oberfläche
 import React from 'react';
 import { useStore } from './store.js';
-import Gallery from './components/Gallery.jsx';
-import ProjectMenu from './components/ProjectMenu.jsx';
+import TitleBar from './components/TitleBar.jsx';
+import CommandBar from './components/CommandBar.jsx';
+import LeftSidebar from './components/LeftSidebar.jsx';
+import CanvasArea from './components/CanvasArea.jsx';
+import RightInspector from './components/RightInspector.jsx';
+import FooterBar from './components/FooterBar.jsx';
 
 export default function App() {
   const images = useStore((s) => s.images);
+  const project = useStore((s) => s.project);
+  const activeImage = images[0];
   return (
-    <div className="h-screen flex flex-col" data-theme="light">
-      <ProjectMenu />
-      <div className="flex-1 overflow-auto">
-        <Gallery images={images} />
+    <div className="h-screen flex flex-col bg-bg-primary" data-theme="dark">
+      <TitleBar projectName={project?.title} />
+      <CommandBar />
+      <div className="flex flex-1 overflow-hidden">
+        <LeftSidebar images={images} />
+        <CanvasArea activeImage={activeImage} />
+        <RightInspector />
       </div>
+      <FooterBar />
     </div>
   );
 }

--- a/gui/src/components/CanvasArea.jsx
+++ b/gui/src/components/CanvasArea.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Preview from './Preview.jsx';
+
+// Zentraler Arbeitsbereich
+export default function CanvasArea({ activeImage }) {
+  if (!activeImage) {
+    return <div className="flex-1 flex items-center justify-center text-gray-400">Bild auswählen</div>;
+  }
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden">
+      <div className="h-8 bg-bg-secondary flex items-center px-2 text-white text-sm">Tab {activeImage.id}</div>
+      <div className="flex-1 bg-surface-card flex justify-center items-center">
+        <Preview src={activeImage.path} imgId={activeImage.id} maskSrc="" />
+      </div>
+    </div>
+  );
+}

--- a/gui/src/components/CommandBar.jsx
+++ b/gui/src/components/CommandBar.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+// Befehlsleiste mit den Hauptaktionen
+export default function CommandBar() {
+  return (
+    <div className="h-12 flex items-center justify-between px-2 bg-bg-primary text-white shadow">
+      <div className="flex gap-2">
+        <button className="neu px-2" aria-label="Neu">Neu</button>
+        <button className="neu px-2" aria-label="Öffnen">Öffnen</button>
+        <button className="neu px-2" aria-label="Bilder hinzufügen">Bilder</button>
+        <button className="neu px-2" aria-label="Batch">Batch</button>
+        <button className="neu px-2" aria-label="Export">Export</button>
+      </div>
+      <div className="flex items-center gap-4">
+        <label className="flex items-center gap-1 text-xs">
+          GPU
+          <input type="checkbox" className="ml-1" />
+        </label>
+        <select className="bg-bg-secondary text-white text-xs">
+          <option>DE</option>
+          <option>EN</option>
+        </select>
+      </div>
+    </div>
+  );
+}

--- a/gui/src/components/FooterBar.jsx
+++ b/gui/src/components/FooterBar.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+// Statusleiste am unteren Rand
+export default function FooterBar() {
+  return (
+    <div className="h-8 flex items-center justify-between px-2 bg-bg-secondary text-white text-xs">
+      <div className="flex-1">Fortschritt...</div>
+      <div className="flex-1 text-center">Tipp: STRG+Z / STRG+Y</div>
+      <div className="flex-1 text-right">FPS 60</div>
+    </div>
+  );
+}

--- a/gui/src/components/LeftSidebar.jsx
+++ b/gui/src/components/LeftSidebar.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+// Seitenleiste mit Projektdateien und Historie
+export default function LeftSidebar({ images }) {
+  return (
+    <div className="w-60 flex flex-col bg-bg-secondary text-white overflow-auto">
+      <div className="p-2 font-semibold">Projekt-Dateien</div>
+      <ul className="flex-1 px-2 space-y-2">
+        {images.map((img) => (
+          <li key={img.id} className="neu p-1 text-xs flex items-center gap-2">
+            <img src={img.path} alt="thumb" className="w-10 h-10 object-cover" />
+            <span>{img.id}</span>
+          </li>
+        ))}
+      </ul>
+      <div className="p-2">
+        <input
+          type="text"
+          placeholder="Suchen"
+          className="w-full text-black text-xs p-1"
+        />
+      </div>
+    </div>
+  );
+}

--- a/gui/src/components/RightInspector.jsx
+++ b/gui/src/components/RightInspector.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+// Rechte Seitenleiste mit Eigenschaften & Einstellungen
+export default function RightInspector() {
+  return (
+    <div className="w-72 bg-bg-secondary text-white overflow-auto">
+      <div className="p-2 font-semibold">Eigenschaften</div>
+      <div className="p-2 text-xs">Bild-Metadaten...</div>
+    </div>
+  );
+}

--- a/gui/src/components/TitleBar.jsx
+++ b/gui/src/components/TitleBar.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+// Obere Titelleiste mit Logo und Fensterknöpfen
+export default function TitleBar({ projectName }) {
+  return (
+    <div className="h-8 flex items-center justify-between px-2 bg-bg-secondary text-white select-none">
+      <div className="flex items-center gap-2">
+        <div className="w-8 h-8 bg-accent-primary rounded-full flex items-center justify-center">
+          <span className="text-sm">\u{1F4F7}</span>
+        </div>
+        <span className="text-sm">DeZensur › {projectName || 'Kein Projekt'}</span>
+      </div>
+      <div className="flex gap-2">
+        <button className="w-3 h-3 rounded-full bg-red-500" aria-label="Schließen"></button>
+        <button className="w-3 h-3 rounded-full bg-yellow-500" aria-label="Minimieren"></button>
+        <button className="w-3 h-3 rounded-full bg-green-500" aria-label="Maximieren"></button>
+      </div>
+    </div>
+  );
+}

--- a/gui/src/tailwind.css
+++ b/gui/src/tailwind.css
@@ -1,3 +1,20 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+  --bg-primary: #1E1E28;
+  --bg-secondary: #2C2C36;
+  --surface-card: #262630;
+  --accent-primary: #4E9AF1;
+  --accent-positive: #3FB889;
+  --accent-warning: #E9A94B;
+  --accent-error: #E3645B;
+}
+
+.neu {
+  box-shadow:
+    inset 0 0 2px rgba(255, 255, 255, 0.1),
+    0 0 4px rgba(0, 0, 0, 0.6);
+  border-radius: 12px;
+}

--- a/gui/tailwind.config.js
+++ b/gui/tailwind.config.js
@@ -4,7 +4,17 @@ export default {
     './src/**/*.{js,jsx}'
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        'bg-primary': '#1E1E28',
+        'bg-secondary': '#2C2C36',
+        'surface-card': '#262630',
+        'accent-primary': '#4E9AF1',
+        'accent-positive': '#3FB889',
+        'accent-warning': '#E9A94B',
+        'accent-error': '#E3645B',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- implement a minimal Desktop-Layout für die Electron/React-Oberfläche
- Ergänzung der Tailwind-Konfiguration um Farbtokens
- README und CHANGELOG dokumentieren das neue Layout

## Testing
- `PYTHONPATH=tests pytest -q`
- `npm test` *(scheiterte: jest nicht gefunden)*

------
https://chatgpt.com/codex/tasks/task_e_6878ccbc344483278b3396f4bd3e64a0