### PR TITLE
Add mockup HTML pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -423,3 +423,9 @@ Alle Änderungen werden in diesem Dokument festgehalten.
   Befehlsleiste und Seitenleisten.
 - Tailwind-Konfiguration enthält nun Farbtokens für das Dark-Theme.
 
+## [1.5.1] – 2025-09-10
+### Hinzugefügt
+- Ordner `mockups/` mit zwei HTML-Dateien als Vorschau auf die
+  Desktop-Oberfläche (Front und Backstage).
+- README beschreibt, wie die Mockups genutzt werden können.
+

--- a/README.md
+++ b/README.md
@@ -302,6 +302,15 @@ Projektordner gespeichert.
 Versucht man, ohne geöffnetes Projekt Bilder hinzuzufügen, erscheint nun eine
 Hinweismeldung.
 
+## Mockups
+
+Im Ordner `mockups/` liegen zwei HTML-Dateien, die das geplante
+Desktop-Layout von DeZensur demonstrieren.
+`front.html` zeigt die normale Benutzeroberfläche, `backstage.html` die
+Einstellungs-Ansicht. Du kannst die Dateien einfach im Browser öffnen, um
+einen ersten Eindruck vom Dark-Theme und der Anordnung der Bereiche zu
+erhalten.
+
 ---
 
 ## Mitwirken

--- a/mockups/backstage.html
+++ b/mockups/backstage.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="UTF-8" />
+<title>DeZensur Backstage Mockup</title>
+<link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="title-bar neu">
+    <div class="logo">DZ</div>
+    <div class="breadcrumb">DeZensur › Einstellungen</div>
+    <div class="window-btns"><span></span><span></span><span></span></div>
+  </div>
+  <div class="command-bar neu">
+    <div>
+      <button>Allgemein</button>
+      <button>Modelle</button>
+      <button>Updates</button>
+    </div>
+    <div></div>
+  </div>
+  <div class="main">
+    <div class="sidebar neu">
+      <h3>Logs</h3>
+      <ul>
+        <li>01:23 Lade Modell...</li>
+        <li>01:25 Fertig</li>
+      </ul>
+    </div>
+    <div class="canvas neu">
+      <h3>Backstage-Bereich</h3>
+      <p>Hier erscheinen Einstellungen und Fortschrittsanzeigen.</p>
+    </div>
+    <div class="inspector neu">
+      <h3>AI-Modelle</h3>
+      <p>Segmenter: HQ-SAM</p>
+      <p>Inpainter: LaMa</p>
+    </div>
+  </div>
+  <div class="footer neu">
+    <div>Speicher 1.2GB</div>
+    <div>Version 1.5.1</div>
+    <div>GPU 80%</div>
+  </div>
+</body>
+</html>

--- a/mockups/front.html
+++ b/mockups/front.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="UTF-8" />
+<title>DeZensur Front Mockup</title>
+<link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="title-bar neu">
+    <div class="logo">DZ</div>
+    <div class="breadcrumb">DeZensur › Projekt XY</div>
+    <div class="window-btns"><span></span><span></span><span></span></div>
+  </div>
+  <div class="command-bar neu">
+    <div>
+      <button>Neu</button>
+      <button>Öffnen</button>
+      <button>Bilder</button>
+      <button>Batch</button>
+      <button>Export</button>
+    </div>
+    <div>
+      <label>GPU <input type="checkbox" /></label>
+      <select><option>DE</option><option>EN</option></select>
+    </div>
+  </div>
+  <div class="main">
+    <div class="sidebar neu">
+      <h3>Projekt-Dateien</h3>
+      <ul>
+        <li>Bild 1 ✓</li>
+        <li>Bild 2 ✎</li>
+        <li>Bild 3 ⚠️</li>
+      </ul>
+    </div>
+    <div class="canvas neu">
+      <div class="overlay-toolbar">
+        <button>A</button>
+        <button>B</button>
+        <button>C</button>
+      </div>
+    </div>
+    <div class="inspector neu">
+      <h3>Eigenschaften</h3>
+      <p>Auflösung: 1024x768</p>
+    </div>
+  </div>
+  <div class="footer neu">
+    <div>Fortschritt</div>
+    <div>Tipps</div>
+    <div>FPS 60</div>
+  </div>
+</body>
+</html>

--- a/mockups/styles.css
+++ b/mockups/styles.css
@@ -1,0 +1,95 @@
+:root {
+  --bg-primary: #1E1E28;
+  --bg-secondary: #2C2C36;
+  --surface-card: #262630;
+  --accent-primary: #4E9AF1;
+  --accent-positive: #3FB889;
+  --accent-warning: #E9A94B;
+  --accent-error: #E3645B;
+  font-size: 14px;
+}
+body {
+  margin: 0;
+  background: var(--bg-primary);
+  color: #fff;
+  font-family: 'Inter', 'Roboto', sans-serif;
+}
+.neu {
+  box-shadow: inset 2px 2px 4px rgba(0,0,0,0.4), 2px 2px 4px rgba(0,0,0,0.6);
+  border-radius: 12px;
+}
+.title-bar {
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 8px;
+  background: var(--bg-secondary);
+}
+.breadcrumb {
+  flex: 1;
+  text-align: center;
+  font-weight: 600;
+  font-size: 24px;
+}
+.window-btns { display:flex; gap:8px; }
+.window-btns span {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--accent-primary);
+}
+.command-bar {
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 8px;
+  background: var(--surface-card);
+}
+.command-bar button {
+  background: var(--bg-secondary);
+  border: none;
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: 8px;
+  margin-right: 4px;
+}
+.main {
+  display: grid;
+  grid-template-columns: 240px 1fr 300px;
+  gap: 12px;
+  padding: 12px;
+  height: calc(100vh - 32px - 48px - 32px);
+}
+.sidebar, .inspector {
+  background: var(--bg-secondary);
+  overflow: auto;
+}
+.canvas {
+  background: var(--surface-card);
+  position: relative;
+}
+.footer {
+  height: 32px;
+  background: var(--surface-card);
+  display:flex;
+  align-items:center;
+  justify-content: space-between;
+  padding: 0 8px;
+}
+.overlay-toolbar {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  display: flex;
+  gap: 8px;
+}
+.overlay-toolbar button {
+  background: var(--bg-secondary);
+  border: none;
+  color: #fff;
+  padding: 4px;
+  border-radius: 8px;
+}


### PR DESCRIPTION
## Summary
- add simple mockups for Front- and Backstage-View
- document the new mockups in README
- record addition in CHANGELOG

## Testing
- `PYTHONPATH=tests pytest -qq`

------
https://chatgpt.com/codex/tasks/task_e_6878cf410b408327a7e8613fbf4b3d17