### PR TITLE
Fix electron-trpc dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -439,3 +439,7 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 ### Hinzugefügt
 - IPC-Kommunikation nutzt jetzt **electron-trpc** mit Typsicherheit.
 - Preload und Renderer binden die IPC-Routen automatisch ein.
+
+## [1.7.1] – 2025-09-13
+### Geändert
+- Da Version 0.12.0 noch nicht veröffentlicht ist, nutzt die GUI `electron-trpc` jetzt fest Version 0.11.x.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ build` ausgeführt wurde. Ohne diesen Build bleibt das Fenster leer.
 
 Ab Version 1.3.3 nutzt die neue TypeScript-Oberflaeche mit TanStack Router. Nach `npm install` startest du die Entwicklung mit `npm run dev`. Der E2E-Test laeuft mit `npx playwright test`.
 Seit Version 1.7.0 kommuniziert das Frontend dank **electron-trpc** typisiert mit dem Python-Backend.
+Da die Version 0.12.0 noch nicht im npm-Registry verfügbar war, ist `electron-trpc` aktuell auf ^0.11.0 festgeschrieben.
 Beim Start prüft das Skript, ob neue Commits auf `origin/main` vorhanden sind
 und zieht sie automatisch. Anschließend installiert es alle
 Abhängigkeiten. Beim ersten Durchlauf lädt das

--- a/gui/package.json
+++ b/gui/package.json
@@ -36,7 +36,7 @@
     "jest-environment-jsdom": "^29.0.0",
     "typescript": "^5.4.0",
     "@tanstack/react-router": "^1.0.0",
-    "electron-trpc": "^0.12.0",
+    "electron-trpc": "^0.11.0",
     "playwright": "^1.42.0"
   },
   "build": {


### PR DESCRIPTION
## Summary
- pin electron-trpc to ^0.11.0 to avoid missing 0.12.0
- note electron-trpc version in README
- document change in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878d7a4df988327961313a967576407