### PR TITLE
Fehlerhinweis bei npm install angepasst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -443,3 +443,7 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 ## [1.7.1] – 2025-09-13
 ### Geändert
 - Da Version 0.12.0 noch nicht veröffentlicht ist, nutzt die GUI `electron-trpc` jetzt fest Version 0.11.x.
+
+## [1.7.2] – 2025-09-14
+### Geändert
+- Das Startskript erwähnt bei einem fehlgeschlagenen `npm install` nun `electron-trpc` statt `electron-reload`.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ build` ausgeführt wurde. Ohne diesen Build bleibt das Fenster leer.
 Ab Version 1.3.3 nutzt die neue TypeScript-Oberflaeche mit TanStack Router. Nach `npm install` startest du die Entwicklung mit `npm run dev`. Der E2E-Test laeuft mit `npx playwright test`.
 Seit Version 1.7.0 kommuniziert das Frontend dank **electron-trpc** typisiert mit dem Python-Backend.
 Da die Version 0.12.0 noch nicht im npm-Registry verfügbar war, ist `electron-trpc` aktuell auf ^0.11.0 festgeschrieben.
+Schlägt `npm install` dennoch fehl, weist das Startskript nun darauf hin, die Version von `electron-trpc` anzupassen.
 Beim Start prüft das Skript, ob neue Commits auf `origin/main` vorhanden sind
 und zieht sie automatisch. Anschließend installiert es alle
 Abhängigkeiten. Beim ersten Durchlauf lädt das

--- a/start.py
+++ b/start.py
@@ -389,10 +389,10 @@ def main() -> None:
             # Nach erfolgreicher Installation Sicherheitsprüfung ausführen
             run_npm_audit()
         except subprocess.CalledProcessError:
-            # Hinweis für den Nutzer, falls ein Paket wie electron-reload nicht verfügbar ist
+            # Hinweis für den Nutzer, falls ein Paket wie electron-trpc nicht verfügbar ist
             print(
                 "npm install schlug fehl. Bitte Prüfe die Internetverbindung "
-                "oder passe die Version von electron-reload im package.json an."
+                "oder passe die Version von electron-trpc im package.json an."
             )
             raise
     elif skip_npm:


### PR DESCRIPTION
## Zusammenfassung
- Fehlernachricht in `start.py` korrigiert, sodass nun auf `electron-trpc` verwiesen wird
- README und CHANGELOG entsprechend aktualisiert

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878dad626b08327805708226084efc4