### PR TITLE
Fix devtools autofill errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -453,3 +453,6 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 - Das GUI-Build schlug wegen einer nicht vorhandenen Version von `electron-trpc` fehl. Die Abhängigkeit ist nun auf ^0.7.1 begrenzt.
 ### Geändert
 - README und `package.json` weisen auf die korrigierte Version hin.
+## [1.7.4] - 2025-09-16
+### Geändert
+- Electron deaktiviert jetzt das Autofill-Feature, um DevTools-Fehler zu vermeiden.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Ab Version 1.3.3 nutzt die neue TypeScript-Oberflaeche mit TanStack Router. Nach
 Seit Version 1.7.0 kommuniziert das Frontend dank **electron-trpc** typisiert mit dem Python-Backend.
 Da im npm-Registry nur Versionen bis 0.7.1 verfügbar sind, ist `electron-trpc` aktuell auf ^0.7.1 festgeschrieben.
 Schlägt `npm install` dennoch fehl, weist das Startskript nun darauf hin, die Version von `electron-trpc` anzupassen.
+Seit Version 1.7.4 unterdrückt Electron die Autofill-Funktion, damit im Terminal keine DevTools-Fehler mehr erscheinen.
 Beim Start prüft das Skript, ob neue Commits auf `origin/main` vorhanden sind
 und zieht sie automatisch. Anschließend installiert es alle
 Abhängigkeiten. Beim ersten Durchlauf lädt das

--- a/gui/electron/main.js
+++ b/gui/electron/main.js
@@ -6,6 +6,9 @@ import fs from 'fs';
 import http from 'http';
 import { fileURLToPath } from 'url';
 
+// Unterdrückt Autofill-Fehler der DevTools
+app.commandLine.appendSwitch('disable-features', 'Autofill');
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 let mainWindow;
 


### PR DESCRIPTION
## Summary
- suppress autofill warnings by disabling Chrome autofill
- document the change in README and CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878df4c6ca4832796a5d961b5b1ea52