### PR TITLE
feat(gallery): implement Add Images dialog, state, thumbnail grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -466,3 +466,7 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 ### Behoben
 - `vite.config.ts` enthält nun ebenfalls den Basis-Pfad `./`, womit Electron die
   gebauten Assets fehlerfrei lädt.
+
+## [1.7.7] - 2025-07-17
+### Hinzugefügt
+- "Add Images" Dialog inklusive Galerie-Grid und Auswahlfunktion

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Es kombiniert modernste Open-Source-Modelle:
 
 ## Funktionsübersicht
 
-1. **Bild-/Ordner-Import**  
+1. **Bild-/Ordner-Import** über `File → Add Images…` oder Drag & Drop
 2. **Automatische Zensur-Erkennung** (Bounding-Boxen via `anime_censor_detection`)  
 3. **Masken-Verfeinerung** mit SAM-HQ  
 4. **Inpainting** der Maskenbereiche (modell-wählbar)  
@@ -346,7 +346,7 @@ PYTHONPATH=tests pytest -q
 
 ## TODO-Liste (Auszug)
 
-* [ ] React-Galerie-Komponente fertigstellen
+* [x] React-Galerie-Komponente fertigstellen
 * [ ] Asynchrones Laden großer Ordner
 * [ ] Fortschritts-Overlay für Batch-Jobs
 * [ ] GPU-vs-CPU-Fallback automatisieren

--- a/gui/__tests__/galleryStore.test.ts
+++ b/gui/__tests__/galleryStore.test.ts
@@ -1,0 +1,14 @@
+import { useGalleryStore } from '../src/renderer/stores/useGalleryStore';
+
+describe('addImages', () => {
+  beforeEach(() => {
+    useGalleryStore.setState({ images: [], selectedId: null });
+  });
+
+  test('fügt eindeutige IDs hinzu und ignoriert Duplikate', () => {
+    useGalleryStore.getState().addImages(['/a.png', '/b.png', '/a.png']);
+    const images = useGalleryStore.getState().images;
+    expect(images).toHaveLength(2);
+    expect(images[0].id).not.toBe(images[1].id);
+  });
+});

--- a/gui/package.json
+++ b/gui/package.json
@@ -9,7 +9,8 @@
     "electron-dev": "electron .",
     "build": "vite build --config vite.config.ts && electron-builder",
     "start": "electron .",
-    "test": "jest"
+    "test": "jest",
+    "e2e": "playwright test"
   },
   "author": "",
   "license": "MIT",
@@ -38,6 +39,10 @@
     "@tanstack/react-router": "^1.0.0",
     "electron-trpc": "^0.7.1",
     "playwright": "^1.42.0"
+  },
+  "dependencies": {
+    "uuid": "^9.0.0",
+    "react-intersection-observer": "^9.4.0"
   },
   "build": {
     "appId": "com.dezensur.app",

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow } from 'electron';
+import { app, BrowserWindow, ipcMain, dialog } from 'electron';
 import { join } from 'path';
 import { registerIpc } from './ipc';
 
@@ -25,6 +25,13 @@ function createWindow() {
 app.whenReady().then(() => {
   createWindow();
   registerIpc();
+  ipcMain.handle('dialog:openImages', async () => {
+    const result = await dialog.showOpenDialog({
+      filters: [{ name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'webp', 'bmp'] }],
+      properties: ['openFile', 'multiSelections'],
+    });
+    return result.filePaths;
+  });
 });
 
 app.on('window-all-closed', () => {

--- a/gui/src/main/preload.ts
+++ b/gui/src/main/preload.ts
@@ -1,7 +1,12 @@
-import { contextBridge } from 'electron';
+import { contextBridge, ipcRenderer } from 'electron';
 import { createIPCInvoker } from 'electron-trpc/preload';
 import type { AppRouter } from './ipc';
 
 // Stellt die tRPC-API im Renderer bereit
 const api = createIPCInvoker<AppRouter>();
 contextBridge.exposeInMainWorld('api', api);
+
+// Stellt eine Funktion bereit, um Bilddateien auszuwählen
+contextBridge.exposeInMainWorld('dialogs', {
+  openImages: () => ipcRenderer.invoke('dialog:openImages'),
+});

--- a/gui/src/renderer/components/AppBar.tsx
+++ b/gui/src/renderer/components/AppBar.tsx
@@ -1,12 +1,47 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { useGalleryStore } from '../stores/useGalleryStore';
+
+declare global {
+  interface Window {
+    dialogs: { openImages: () => Promise<string[]> };
+  }
+}
 
 // Oberste App-Bar mit Logo und Menüs
 export default function AppBar() {
+  const addImages = useGalleryStore((s) => s.addImages);
+  const [openFile, setOpenFile] = useState(false);
+
+  async function handleAdd() {
+    const paths = await window.dialogs.openImages();
+    if (paths && paths.length) addImages(paths);
+  }
+
+  useEffect(() => {
+    const key = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'o') {
+        e.preventDefault();
+        handleAdd();
+      }
+    };
+    window.addEventListener('keydown', key);
+    return () => window.removeEventListener('keydown', key);
+  }, []);
+
   return (
-    <header className="h-15 flex items-center px-4 bg-[#1e1e2f] text-white">
+    <header className="h-15 flex items-center px-4 bg-[#1e1e2f] text-white relative">
       <h1 className="font-semibold mr-auto">DeZensur</h1>
       <nav className="space-x-4 hidden md:block">
-        <button className="hover:underline">File</button>
+        <div className="inline-block relative">
+          <button className="hover:underline" onClick={() => setOpenFile(!openFile)}>File</button>
+          {openFile && (
+            <div className="absolute left-0 mt-1 w-40 bg-gray-800 border border-gray-700 z-10">
+              <button className="block w-full text-left px-2 py-1 hover:bg-gray-700" onClick={handleAdd}>
+                Add Images…
+              </button>
+            </div>
+          )}
+        </div>
         <button className="hover:underline">Edit</button>
         <button className="hover:underline">View</button>
         <button className="hover:underline">Help</button>

--- a/gui/src/renderer/components/Gallery.tsx
+++ b/gui/src/renderer/components/Gallery.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Thumb from './Thumb';
+import { useGalleryStore } from '../stores/useGalleryStore';
+
+// Zeigt die Bildliste als Grid an
+export default function Gallery() {
+  const images = useGalleryStore((s) => s.images);
+  if (!images.length) {
+    return (
+      <div className="p-4 text-center text-sm text-gray-400">
+        Drag &amp; Drop images or use <strong>File → Add Images…</strong>
+      </div>
+    );
+  }
+  return (
+    <div className="grid grid-cols-[repeat(auto-fill,minmax(180px,1fr))] gap-4 p-4">
+      {images.map((img) => (
+        <Thumb key={img.id} image={img} />
+      ))}
+    </div>
+  );
+}
+

--- a/gui/src/renderer/components/GalleryPane.tsx
+++ b/gui/src/renderer/components/GalleryPane.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import Gallery from './Gallery';
 
-// Platzhalter für die Bildergalerie
+// Anzeige der Thumbnails im Hauptbereich
 export default function GalleryPane() {
   return (
-    <section className="flex-1 overflow-auto p-4 bg-gray-900 text-white">
-      Galerie
+    <section className="flex-1 overflow-auto bg-gray-900 text-white">
+      <Gallery />
     </section>
   );
 }

--- a/gui/src/renderer/components/Thumb.tsx
+++ b/gui/src/renderer/components/Thumb.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { useInView } from 'react-intersection-observer';
+import { ImageMeta, useGalleryStore } from '../stores/useGalleryStore';
+
+// Einzelnes Thumbnail in der Galerie
+export default function Thumb({ image }: { image: ImageMeta }) {
+  const { ref, inView } = useInView({ triggerOnce: true });
+  const selectedId = useGalleryStore((s) => s.selectedId);
+  const select = useGalleryStore((s) => s.select);
+  return (
+    <button
+      ref={ref}
+      onClick={() => select(image.id)}
+      className={`w-40 h-40 rounded-lg shadow-sm overflow-hidden ${
+        selectedId === image.id ? 'ring-2 ring-blue-500' : ''
+      }`}
+    >
+      {inView && (
+        <img
+          src={image.path}
+          alt={image.name}
+          className="w-full h-full object-cover"
+        />
+      )}
+    </button>
+  );
+}
+

--- a/gui/src/renderer/stores/useGalleryStore.ts
+++ b/gui/src/renderer/stores/useGalleryStore.ts
@@ -1,0 +1,36 @@
+import { create } from 'zustand';
+import { v4 as uuidv4 } from 'uuid';
+
+// Metadaten eines Bildes
+export interface ImageMeta {
+  id: string;
+  path: string;
+  name: string;
+}
+
+interface GalleryState {
+  images: ImageMeta[];
+  selectedId: string | null;
+  addImages: (paths: string[]) => void;
+  select: (id: string) => void;
+}
+
+// Zustand für die Galerie
+export const useGalleryStore = create<GalleryState>((set, get) => ({
+  images: [],
+  selectedId: null,
+  addImages: (paths) => {
+    const existing = new Set(get().images.map((i) => i.path));
+    const added = paths
+      .filter((p) => !existing.has(p))
+      .map((p) => ({
+        id: uuidv4(),
+        path: 'file://' + p,
+        name: p.split(/[/\\]/).pop() || '',
+      }));
+    if (added.length) {
+      set((s) => ({ images: [...s.images, ...added] }));
+    }
+  },
+  select: (id) => set({ selectedId: id }),
+}));

--- a/gui/tests/e2e/addImages.spec.ts
+++ b/gui/tests/e2e/addImages.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test';
+
+test('Bilder werden über Shortcut hinzugefügt', async ({ page }) => {
+  await page.goto('http://localhost:5173');
+  await page.evaluate(() => {
+    window.dialogs = { openImages: async () => ['/tmp/1.png', '/tmp/2.png'] } as any;
+  });
+  await page.keyboard.press('Control+O');
+  const thumbs = page.locator('img');
+  await expect(thumbs).toHaveCount(2);
+});


### PR DESCRIPTION
## Summary
- add UUID and intersection-observer dependencies
- expose `dialog:openImages` via preload and main process
- manage gallery state with `useGalleryStore`
- implement `Thumb` and `Gallery` components
- hook up menu in `AppBar` with shortcut
- add unit and e2e tests
- document new feature in README and CHANGELOG

## Testing
- `npm run test` *(fails: jest not found)*
- `npm run e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879251feef08327b62dd71f8de53fad