### PR TITLE
Automatischer MobileSAM Fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -535,3 +535,10 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 - Neuer Test `tests/test_dep_manager.py::test_version_update`
 ### Geändert
 - README hakt den Punkt "Dynamischer Model-Manager" ab
+
+## [1.8.7] - 2025-09-28
+### Hinzugefügt
+- Automatischer Fallback auf **MobileSAM** bei fehlender GPU
+- Neuer Test `tests/test_segmenter_mobile_fallback.py`
+### Geändert
+- TODO-Board markiert den MobileSAM-Fallback als erledigt

--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ MIT – siehe [LICENSE](LICENSE)
   - [x] 🔬 `tests/detector/test_thresholds.py`
 - [ ] **Segmenter Module**
   - [ ] SAM‑HQ GPU‑Pipeline
-  - [ ] MobileSAM Fallback (CPU)
-  - [ ] 🔬 `tests/segmenter/test_mobile_fallback.py`
+  - [x] MobileSAM Fallback (CPU)
+  - [x] 🔬 `tests/segmenter/test_mobile_fallback.py`
 - [ ] **Inpainter**
   - [ ] Diffusers Pipeline mit ControlNet‑Aux
   - [ ] Lama‑Cleaner Classical Fallback

--- a/core/segmenter.py
+++ b/core/segmenter.py
@@ -22,6 +22,11 @@ LOGGER = get_logger(__name__)
 def load_sam(model_key: str) -> SamPredictor:
     """Lädt ein SAM-Modell und cached den Predictor."""
 
+    # Bei fehlender GPU automatisch auf MobileSAM ausweichen
+    if model_key == "sam_vit_hq" and not is_gpu_available():
+        LOGGER.info("GPU nicht vorhanden, nutze MobileSAM")
+        model_key = "sam_mobile"
+
     model_path = ensure_model(model_key)
     model_type = "vit_t" if model_key == "sam_mobile" else "vit_h"
     LOGGER.info("Lade SAM-Modell {}", model_path)

--- a/tests/test_segmenter_mobile_fallback.py
+++ b/tests/test_segmenter_mobile_fallback.py
@@ -1,0 +1,35 @@
+import importlib
+import sys
+from pathlib import Path
+
+sys.modules['segment_anything'] = importlib.import_module('tests.segment_anything')
+sys.modules['PIL'] = importlib.import_module('tests.PIL')
+sys.modules['numpy'] = importlib.import_module('tests.numpy')
+sys.modules['requests'] = importlib.import_module('tests.requests')
+sys.modules['torch'] = importlib.import_module('tests.torch')
+sys.modules['huggingface_hub'] = importlib.import_module('tests.huggingface_hub')
+sys.modules['tqdm'] = importlib.import_module('tests.tqdm')
+sys.modules['loguru'] = importlib.import_module('tests.loguru')
+
+from core import segmenter
+
+
+def test_mobile_fallback(monkeypatch, tmp_path: Path) -> None:
+    # Cache leeren, damit das Modell neu geladen wird
+    segmenter.load_sam.cache_clear()
+
+    img = tmp_path / "img.png"
+    from PIL import Image
+    Image.new("RGB", (8, 8)).save(img)
+
+    loaded = {}
+
+    def fake_ensure_model(key: str):
+        loaded['key'] = key
+        return tmp_path / f"{key}.pth"
+
+    monkeypatch.setattr(segmenter, 'ensure_model', fake_ensure_model)
+    monkeypatch.setattr(segmenter, 'is_gpu_available', lambda: False)
+
+    segmenter.generate_mask(img, [{"type": "box", "data": [0, 0, 7, 7]}])
+    assert loaded['key'] == 'sam_mobile'


### PR DESCRIPTION
## Zusammenfassung
- MobileSAM-Fallback bei fehlender GPU
- passender Test `test_segmenter_mobile_fallback`
- README und Changelog angepasst

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b857f9acc83278af47f81a85b96ab