### PR TITLE
Implementierte einfache i18n-Unterstützung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -548,3 +548,11 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 - Neuer Test `tests/test_segmenter_gpu_pipeline.py`
 ### Geändert
 - README hakt die SAM-HQ GPU-Pipeline und den Lama-Fallback ab
+
+## [1.8.9] - 2025-09-30
+### Hinzugefügt
+- Einfache i18n-Unterstützung mit `de` und `en` JSON-Bundles
+- Zustands-Store zur Laufzeitumschaltung der Sprache
+- Neuer Test `tests/i18n/test_loader.py`
+### Geändert
+- README erklärt den Sprachwechsel und markiert das TODO als erledigt

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Alle Modelle laufen **offline** auf deiner GPU / CPU – keine Cloud‑Abhä
 - [ ] Zoom & Pan‑Werkzeuge  
 - [ ] Fortschritts‑Modal für lange Tasks  
 - [ ] Einstellungs‑Dialog (Modelle, Hardware, Pfade)  
-- [ ] Mehrsprachigkeit (i18n)
+ - [x] Mehrsprachigkeit (i18n)
 
 ### DevOps
 
@@ -91,6 +91,11 @@ python start.py          # erstellt venv, lädt Modelle, baut GUI
 # Dev‑Modus:
 python start.py --dev    # Hot‑Reload für Front‑ und Backend
 ```
+
+### Sprache umschalten
+
+Oben rechts in der GUI kannst du zwischen **DE** und **EN** wählen. Die zugehörigen
+JSON-Dateien findest du unter `gui/src/i18n/`.
 
 ### Batch-Reports erstellen
 
@@ -215,10 +220,10 @@ MIT – siehe [LICENSE](LICENSE)
   - [ ] GPU Auswahl / CPU‑Fallback
   - [ ] Modelle nach­laden (+ Checksum)
   - [ ] 🔬 Unit `src/__tests__/settings.spec.tsx`
-- [ ] **i18n**
-  - [ ] Deutsch / Englisch JSON Bundles
-  - [ ] Runtime‑Language Switch
-  - [ ] 🔬 `tests/i18n/test_loader.py`
+ - [x] **i18n**
+  - [x] Deutsch / Englisch JSON Bundles
+  - [x] Runtime‑Language Switch
+  - [x] 🔬 `tests/i18n/test_loader.py`
 
 ### 3️⃣ CLI‑&‑Batch‑Tools
 - [x] `dez detect <folder>` → JSON Report

--- a/core/i18n.py
+++ b/core/i18n.py
@@ -1,0 +1,21 @@
+"""Lädt Übersetzungsdateien aus dem GUI-Ordner."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from functools import lru_cache
+
+
+@lru_cache(maxsize=None)
+def load_translations(lang: str) -> dict[str, str]:
+    """Gibt das Übersetzungs-Dictionary für die gewünschte Sprache zurück."""
+    base = Path(__file__).resolve().parents[1] / "gui" / "src" / "i18n"
+    path = base / f"{lang}.json"
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def translate(lang: str, key: str) -> str:
+    """Liefert die Übersetzung oder den Schlüssel selbst."""
+    return load_translations(lang).get(key, key)

--- a/gui/src/i18n/de.json
+++ b/gui/src/i18n/de.json
@@ -1,0 +1,4 @@
+{
+  "file": "Datei",
+  "add_images": "Bilder hinzufügen…"
+}

--- a/gui/src/i18n/en.json
+++ b/gui/src/i18n/en.json
@@ -1,0 +1,4 @@
+{
+  "file": "File",
+  "add_images": "Add Images…"
+}

--- a/gui/src/renderer/components/AppBar.tsx
+++ b/gui/src/renderer/components/AppBar.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useGalleryStore } from '../stores/useGalleryStore';
 import { useProjectStore } from '../stores/useProjectStore';
+import { useLocaleStore, Lang } from '../stores/useLocaleStore';
 
 declare global {
   interface Window {
@@ -18,6 +19,9 @@ export default function AppBar() {
   const [openFile, setOpenFile] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [gpu, setGpu] = useState(true);
+  const lang = useLocaleStore((s) => s.lang);
+  const setLang = useLocaleStore((s) => s.setLang);
+  const t = useLocaleStore((s) => s.t);
 
   async function handleAdd() {
     // Bilder auswählen und sowohl in die Galerie
@@ -64,11 +68,11 @@ export default function AppBar() {
       <h1 className="font-semibold mr-auto">DeZensur</h1>
       <nav className="space-x-4 hidden md:block">
         <div className="inline-block relative">
-          <button className="hover:underline" onClick={() => setOpenFile(!openFile)}>File</button>
+          <button className="hover:underline" onClick={() => setOpenFile(!openFile)}>{t('file')}</button>
           {openFile && (
             <div className="absolute left-0 mt-1 w-40 bg-gray-800 border border-gray-700 z-10">
               <button className="block w-full text-left px-2 py-1 hover:bg-gray-700" onClick={handleAdd}>
-                Add Images…
+                {t('add_images')}
               </button>
             </div>
           )}
@@ -81,6 +85,14 @@ export default function AppBar() {
         <button aria-label="Settings" onClick={toggleSettings}>⚙</button>
         <button aria-label="GPU-Status" onClick={toggleGpu}>{gpu ? '🖥' : '💻'}</button>
         <button aria-label="Working-Dir" onClick={chooseDir}>📁</button>
+        <select
+          value={lang}
+          onChange={(e) => setLang(e.target.value as Lang)}
+          className="bg-gray-800 text-white text-xs"
+        >
+          <option value="de">DE</option>
+          <option value="en">EN</option>
+        </select>
       </div>
       {showSettings && (
         <div className="absolute right-2 top-12 bg-gray-800 border border-gray-700 p-2 z-10">

--- a/gui/src/renderer/stores/useLocaleStore.ts
+++ b/gui/src/renderer/stores/useLocaleStore.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand';
+import de from '../../i18n/de.json';
+import en from '../../i18n/en.json';
+
+// Unterstuetzte Sprachen
+export type Lang = 'de' | 'en';
+
+const bundles: Record<Lang, Record<string, string>> = { de, en };
+
+// Zustand mit aktueller Sprache und Uebersetzungsfunktion
+export const useLocaleStore = create<{
+  lang: Lang;
+  setLang: (l: Lang) => void;
+  t: (key: string) => string;
+}>((set, get) => ({
+  lang: 'de',
+  setLang: (l) => set({ lang: l }),
+  t: (key) => bundles[get().lang][key] ?? key,
+}));

--- a/tests/i18n/test_loader.py
+++ b/tests/i18n/test_loader.py
@@ -1,0 +1,9 @@
+from core import i18n
+
+
+def test_load_translations() -> None:
+    de = i18n.load_translations("de")
+    en = i18n.load_translations("en")
+    assert de.get("file") == "Datei"
+    assert en.get("add_images") == "Add Images…"
+


### PR DESCRIPTION
## Zusammenfassung
- GUI erhält Spracheinstellungen und Umschalter
- JSON-Bundles für Deutsch und Englisch ergänzt
- neuer Locale-Store und Python-Lader
- README und TODO-Board aktualisiert
- CHANGELOG auf Version 1.8.9 erweitert

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687b8b9c1de88327a32e9ef59f78a36b