### PR TITLE
Implement Tile-Renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -604,3 +604,10 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 - Jest-Test `zoom with wheel` deckt das neue Feature ab
 ### Geändert
 - README markiert Zoom & Pan als erledigt
+
+## [1.8.17] - 2025-10-08
+### Hinzugefügt
+- Asynchrone Tile-Render-Engine mit Abbruch- und Resume-Funktion
+- Unit-Test `tests/render/test_resume.py`
+### Geändert
+- README hakt die Render-Engine im TODO-Board ab

--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ python generate_report.py projekt.dezproj 20240719 --report batch.json --html ba
 ```
 Der JSON- und optional der HTML-Report liegen anschließend im angegebenen Pfad.
 
+### Tile-Renderer
+
+Die Render-Engine zerlegt Bilder in Kacheln und kann jederzeit pausiert werden.
+Beim erneuten Start setzt sie den letzten Stand fort.
+
 ### Zensur-Scan per CLI
 
 Mit dem Skript `dez.py` lässt sich ein kompletter Ordner analysieren:
@@ -231,10 +236,10 @@ MIT – siehe [LICENSE](LICENSE)
   - [x] Diffusers Pipeline mit ControlNet‑Aux
   - [x] Lama‑Cleaner Classical Fallback
   - [x] 🔬 `tests/inpaint/test_seams.py`
-- [ ] **Render‑Engine**
-  - [ ] Async Tile‑Renderer
-  - [ ] Abort/Resume Support
-  - [ ] 🔬 `tests/render/test_resume.py`
+- [x] **Render‑Engine**
+  - [x] Async Tile‑Renderer
+  - [x] Abort/Resume Support
+  - [x] 🔬 `tests/render/test_resume.py`
 
 ### 2️⃣ Desktop‑GUI (Electron + React Konva)
 - [ ] **Galerie‑View**

--- a/core/render_engine.py
+++ b/core/render_engine.py
@@ -1,0 +1,57 @@
+"""Asynchrone Tile-Render-Engine mit Abbruch- und Resume-Funktion."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Iterable, Tuple, Set
+
+from PIL import Image
+
+
+class TileRenderer:
+    """Rendert ein Bild kachelweise und erlaubt Pausieren."""
+
+    def __init__(self, image: Image.Image, tile_size: int = 128) -> None:
+        self.image = image
+        self.tile_size = tile_size
+        self.done: Set[Tuple[int, int]] = set()
+        self._abort = False
+
+    def abort(self) -> None:
+        """Bricht den aktuellen Durchlauf nach der laufenden Kachel ab."""
+        self._abort = True
+
+    def get_state(self) -> Set[Tuple[int, int]]:
+        """Gibt bereits gerenderte Kacheln zurück."""
+        return set(self.done)
+
+    def save_state(self, path: Path) -> None:
+        """Speichert den Fortschritt als JSON-Datei."""
+        data = sorted(list(self.done))
+        path.write_text(json.dumps(data), encoding="utf-8")
+
+    def load_state(self, path: Path) -> None:
+        """Lädt zuvor gespeicherten Fortschritt."""
+        if path.exists():
+            data = json.loads(path.read_text(encoding="utf-8"))
+            self.done = {tuple(item) for item in data}
+
+    async def render(self, state: Iterable[Tuple[int, int]] | None = None):
+        """Asynchrone Erzeugung der Bildkacheln."""
+        self._abort = False
+        if state is not None:
+            self.done = set(state)
+        width, height = self.image.size
+        for y in range(0, height, self.tile_size):
+            for x in range(0, width, self.tile_size):
+                if (x, y) in self.done:
+                    continue
+                if self._abort:
+                    return
+                box = (x, y, x + self.tile_size, y + self.tile_size)
+                tile = self.image.crop(box)
+                await asyncio.sleep(0)  # Kontrolle an Eventloop abgeben
+                self.done.add((x, y))
+                yield (x, y), tile

--- a/tests/PIL/__init__.py
+++ b/tests/PIL/__init__.py
@@ -18,6 +18,9 @@ class Image(SimpleNamespace):
     def copy(self):
         return Image(self.size)
 
+    def crop(self, box):
+        return Image((box[2]-box[0], box[3]-box[1]))
+
     def paste(self, img, pos):
         pass
 

--- a/tests/render/test_resume.py
+++ b/tests/render/test_resume.py
@@ -1,0 +1,34 @@
+import importlib
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.modules['PIL'] = importlib.import_module('tests.PIL')
+
+import asyncio
+from PIL import Image
+
+from core.render_engine import TileRenderer
+
+
+def test_resume(tmp_path: Path) -> None:
+    img = Image.new("RGB", (8, 8))
+    engine = TileRenderer(img, tile_size=4)
+
+    tiles = []
+
+    async def run_first():
+        async for pos, _ in engine.render():
+            tiles.append(pos)
+            if len(tiles) == 2:
+                engine.abort()
+    asyncio.run(run_first())
+
+    assert len(engine.get_state()) == 2
+
+    async def run_resume():
+        async for pos, _ in engine.render(state=engine.get_state()):
+            tiles.append(pos)
+    asyncio.run(run_resume())
+
+    assert len(tiles) == 4


### PR DESCRIPTION
## Summary
- implement asynchrone Tile-Render-Engine
- add Test zum Resume der Render-Engine
- TODO-Board und Dokumentation ergaenzt
- CHANGELOG angepasst

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ba7076b10832792120ba3dc4e8411