### PR TITLE
Arbeite TODO-Liste weiter ab

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,10 @@ on:
 jobs:
   python:
     name: Python-Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.10", "3.11"]
     steps:
       - uses: actions/checkout@v4
@@ -19,6 +20,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+      - name: HuggingFace-Cache nutzen
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/huggingface
+          key: hf-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
+          restore-keys: hf-${{ runner.os }}-
       # Installiert die nötigen Python-Pakete
       - name: Abhängigkeiten installieren
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -619,3 +619,10 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 ### Geändert
 - README markiert Projekt-Handling, Masken-Editor und Einstellungs-Dialog als erledigt
 - TODO-Board vermerkt den Modell-Selector
+
+## [1.8.19] - 2025-10-10
+### Hinzugefügt
+- GitHub-Action `ci.yml` mit Windows- und Ubuntu-Matrix
+- Caching für HuggingFace-Modelle
+### Geändert
+- README markiert die GitHub-Actions-Punkte im TODO-Board als erledigt

--- a/README.md
+++ b/README.md
@@ -269,9 +269,9 @@ MIT – siehe [LICENSE](LICENSE)
 - [x] 🔬 `tests/cli/test_help.py`
 
 ### 4️⃣ DevOps & Release
-- [ ] GitHub Actions
-  - [ ] Matrix (windows‑latest / ubuntu‑latest)
-  - [ ] Cashing von HF‑Modellen
+- [x] GitHub Actions
+  - [x] Matrix (windows‑latest / ubuntu‑latest)
+  - [x] Cashing von HF‑Modellen
 - [ ] PyPI Build (`dezensor` Wheel)
 - [ ] Windows x64 Portable `.exe` (PyInstaller + --add‑data assets)
 - [ ] Code‑Signing Setup (signtool)


### PR DESCRIPTION
## Zusammenfassung
- GitHub Actions Workflow erweitert: Matrix aus Windows und Ubuntu, HuggingFace-Cache
- README aktualisiert: DevOps-Bereich hakt CI-Punkte ab
- Changelog um Eintrag 1.8.19 ergänzt

## Testanweisungen
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bad9617988327a1bd46d18f2c1786