### PR TITLE
Implement automatisches Changelog Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract changelog
+        id: changelog
+        run: |
+          python scripts/extract_changelog.py "$TAG" > release_notes.txt
+        env:
+          TAG: ${{ github.ref_name }}
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: release_notes.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -626,3 +626,10 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 - Caching für HuggingFace-Modelle
 ### Geändert
 - README markiert die GitHub-Actions-Punkte im TODO-Board als erledigt
+
+## [1.8.20] - 2025-10-11
+### Hinzugefügt
+- GitHub-Action `release.yml` erstellt Releases aus dem CHANGELOG
+- Skript `scripts/extract_changelog.py` extrahiert die Notizen
+### Geändert
+- README hakt das automatische Changelog-Release ab

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Eine ausführliche Schritt‑für‑Schritt‑Anleitung findest du im [Handbuch]
 - [ ] Portable **EXE‑Build** (PyInstaller)  
 - [ ] Signierter Windows‑Installer  
 - [ ] > 90 % Test‑Coverage  
-- [ ] Automatisches Changelog‑Release (GitHub‑Action)
+- [x] Automatisches Changelog‑Release (GitHub‑Action)
 
 ---
 

--- a/scripts/extract_changelog.py
+++ b/scripts/extract_changelog.py
@@ -1,0 +1,27 @@
+"""Extrahiert den Changelog-Eintrag zu einem gegebenen Tag."""
+
+import sys
+import re
+from pathlib import Path
+
+# Tag-Name vom Git-Event (z.B. v1.2.3)
+tag = sys.argv[1]
+tag = tag.lstrip('v')
+text = Path('CHANGELOG.md').read_text(encoding='utf-8').splitlines()
+# Regex zum Finden der Versionszeilen
+pat = re.compile(r"^## \[(?P<ver>.+?)\]")
+start = None
+for i, line in enumerate(text):
+    # Start-Zeile der gewünschten Version finden
+    m = pat.match(line)
+    if m and m.group('ver') == tag:
+        start = i + 1
+        break
+if start is None:
+    sys.exit(f'Version {tag} nicht gefunden')
+body_lines = []
+for line in text[start:]:
+    if pat.match(line):
+        break
+    body_lines.append(line.rstrip())  # Zeile übernehmen
+print('\n'.join(body_lines).strip())


### PR DESCRIPTION
## Summary
- add GitHub Action `release.yml` to create releases from CHANGELOG
- script `extract_changelog.py` extrahiert Texte für das Release
- TODO-Liste: Changelog Release abgehakt
- CHANGELOG um Version 1.8.20 erweitert

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687bb330c2748327a67f902edf205eb0