### PR TITLE
Todo-Liste: Drag&Drop-Import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -653,3 +653,9 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 - Paket-Metadaten im `pyproject.toml` ermöglichen den PyPI-Build
 ### Geändert
 - README erklärt das Erzeugen eines Wheels und markiert den TODO-Punkt als erledigt
+
+## [1.8.24] - 2025-10-15
+### Hinzugefügt
+- Galerie unterstützt Drag-&-Drop zum Hinzufügen von Bildern
+### Geändert
+- README beschreibt den Import per Drag-&-Drop und hakt den TODO-Punkt ab

--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ Werkzeugleiste lässt sich die Pinselgröße anpassen und per Undo/Redo rückgä
 machen. Halte **Strg** gedrückt und nutze das Mausrad zum Zoomen. Mit gedrückter
 **Leertaste** lässt sich die Ansicht verschieben.
 
+### Bilder importieren
+
+Bilder kannst du direkt per Drag-&-Drop in die Galerie ziehen. Alternativ öffnest du
+**File → Add Images…** oder drückst **Ctrl+O**.
+
 ### Batch-Reports erstellen
 
 Nach einem Batch-Lauf kann ein zusammenfassender Bericht erzeugt werden.
@@ -258,9 +263,9 @@ MIT – siehe [LICENSE](LICENSE)
 
 ### 2️⃣ Desktop‑GUI (Electron + React Konva)
 - [ ] **Galerie‑View**
-  - [ ] Drag‑&‑Drop Import
+  - [x] Drag‑&‑Drop Import
   - [ ] Lazy Thumb Generation (Worker)
-  - [ ] 🔬 Playwright E2E `e2e/gallery.spec.ts`
+  - [x] 🔬 Playwright E2E `e2e/gallery.spec.ts`
   - [x] **Masken‑Editor**
   - [x] Zeichen‑Tool, Radierer, Shortcut (⌘Z)
   - [x] Zoom & Pan (Ctrl + Wheel)

--- a/gui/src/renderer/components/Gallery.tsx
+++ b/gui/src/renderer/components/Gallery.tsx
@@ -1,22 +1,45 @@
 import React from 'react';
 import Thumb from './Thumb';
 import { useGalleryStore } from '../stores/useGalleryStore';
+import { useProjectStore } from '../stores/useProjectStore';
 
 // Zeigt die Bildliste als Grid an
 export default function Gallery() {
   const images = useGalleryStore((s) => s.images);
-  if (!images.length) {
-    return (
-      <div className="p-4 text-center text-sm text-gray-400">
-        Drag &amp; Drop images or use <strong>File → Add Images…</strong>
-      </div>
-    );
+  const addImages = useGalleryStore((s) => s.addImages);
+  const addProjImages = useProjectStore((s) => s.addImages);
+
+  function handleDrop(e: React.DragEvent<HTMLDivElement>) {
+    e.preventDefault();
+    const paths = Array.from(e.dataTransfer.files)
+      .map((f: any) => f.path)
+      .filter(Boolean);
+    if (paths.length) {
+      addImages(paths);
+      addProjImages(paths);
+    }
   }
-  return (
+
+  const content = images.length ? (
     <div className="grid grid-cols-[repeat(auto-fill,minmax(180px,1fr))] gap-4 p-4">
       {images.map((img) => (
         <Thumb key={img.id} image={img} />
       ))}
+    </div>
+  ) : (
+    <div className="p-4 text-center text-sm text-gray-400">
+      Drag &amp; Drop images or use <strong>File → Add Images…</strong>
+    </div>
+  );
+
+  return (
+    <div
+      data-testid="gallery"
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={handleDrop}
+      className="h-full"
+    >
+      {content}
     </div>
   );
 }

--- a/gui/tests/e2e/gallery.spec.ts
+++ b/gui/tests/e2e/gallery.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('Drag & Drop Import fügt Bilder hinzu', async ({ page }) => {
+  await page.goto('http://localhost:5173');
+  const dt = await page.evaluateHandle(() => {
+    const d = new DataTransfer();
+    const f = new File([''], 'drop.png');
+    Object.defineProperty(f, 'path', { value: '/tmp/drop.png' });
+    d.items.add(f);
+    return d;
+  });
+  await page.dispatchEvent('[data-testid="gallery"]', 'dragover', { dataTransfer: dt });
+  await page.dispatchEvent('[data-testid="gallery"]', 'drop', { dataTransfer: dt });
+  const thumbs = page.locator('img');
+  await expect(thumbs).toHaveCount(1);
+});


### PR DESCRIPTION
## Zusammenfassung
- Galerie akzeptiert nun Dateien per Drag&Drop
- neues E2E-Playwright-Testszenario `gallery.spec.ts`
- README beschreibt den Import und hakt den Punkt im TODO-Board ab
- CHANGELOG ergänzt Version 1.8.24

## Testing
- `pytest -q`
- `npm test --prefix gui` *(fehlt Jest-Konfiguration)*
- `npm run --prefix gui e2e` *(Playwright fehlt)*

------
https://chatgpt.com/codex/tasks/task_e_687bbd965ac88327b8457bb54a3ded6a