### PR TITLE
Arbeite TODO ab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -659,3 +659,9 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 - Galerie unterstützt Drag-&-Drop zum Hinzufügen von Bildern
 ### Geändert
 - README beschreibt den Import per Drag-&-Drop und hakt den TODO-Punkt ab
+
+## [1.8.25] - 2025-10-16
+### Hinzugefügt
+- End-to-end-Test `e2e/editor.spec.ts` prüft das Öffnen des Masken-Editors
+### Geändert
+- README hakt den Editor-Test im TODO-Board ab

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ MIT – siehe [LICENSE](LICENSE)
   - [x] **Masken‑Editor**
   - [x] Zeichen‑Tool, Radierer, Shortcut (⌘Z)
   - [x] Zoom & Pan (Ctrl + Wheel)
-  - [ ] 🔬 `e2e/editor.spec.ts`
+  - [x] 🔬 `e2e/editor.spec.ts`
 - [ ] **Side‑Panel**
   - [ ] Kontextabhängige Property‑Leisten
   - [x] Modell‑Selector Dropdown

--- a/gui/tests/e2e/editor.spec.ts
+++ b/gui/tests/e2e/editor.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+// Testet das Öffnen des Masken-Editors über die Vorschau
+
+test('Maskeneditor öffnet sich und zeigt Buttons', async ({ page }) => {
+  await page.goto('http://localhost:5173');
+  await page.evaluate(() => {
+    window.dialogs = { openImages: async () => ['/tmp/edit.png'] } as any;
+  });
+  await page.keyboard.press('Control+O');
+  await page.getByText('Maske editieren').click();
+  await expect(page.getByText('Abbrechen')).toBeVisible();
+  await expect(page.getByText('Speichern')).toBeVisible();
+});


### PR DESCRIPTION
## Zusammenfassung
- Playwright-Test fuer Maskeneditor implementieren
- README-TODO fuer den Editor-Test abgehakt
- CHANGELOG um Version 1.8.25 ergaenzt

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_687bc0b29c5c8327b31230370dca156b