### PR TITLE
Arbeite TODO Side-Panel ab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -678,3 +678,10 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 - Platzhalter-Demo-Assets unter `demo_assets/`
 ### Geändert
 - README markiert Lazy Thumb Generation und Demo Assets im TODO-Board als erledigt
+## [1.8.28] - 2025-10-19
+### Hinzugefügt
+- Kontextabhängige Eigenschaften im Side-Panel
+- End-to-end-Test `e2e/sidepanel.spec.ts`
+### Geändert
+- README markiert die Side-Panel-Punkte im TODO-Board als erledigt und beschreibt die Funktion
+

--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ Bilder kannst du direkt per Drag-&-Drop in die Galerie ziehen. Alternativ öffne
 Beim ersten Anzeigen erzeugt ein Web Worker automatisch verkleinerte Vorschaubilder.
 Beispielbilder findest du im Ordner `demo_assets/`.
 
+### Side-Panel
+
+Nach dem Anklicken eines Bildes erscheinen rechts dessen Eigenschaften
+(ID und Dateiname). Dort wählst du auch das Inpainting-Modell aus.
+
 ### Batch-Reports erstellen
 
 Nach einem Batch-Lauf kann ein zusammenfassender Bericht erzeugt werden.
@@ -283,10 +288,10 @@ MIT – siehe [LICENSE](LICENSE)
   - [x] Zeichen‑Tool, Radierer, Shortcut (⌘Z)
   - [x] Zoom & Pan (Ctrl + Wheel)
   - [x] 🔬 `e2e/editor.spec.ts`
-- [ ] **Side‑Panel**
-  - [ ] Kontextabhängige Property‑Leisten
+- [x] **Side‑Panel**
+  - [x] Kontextabhängige Property‑Leisten
   - [x] Modell‑Selector Dropdown
-  - [ ] 🔬 `e2e/sidepanel.spec.ts`
+  - [x] 🔬 `e2e/sidepanel.spec.ts`
 - [x] **Einstellungs‑Dialog**
   - [x] GPU Auswahl / CPU‑Fallback
   - [x] Modelle nach­laden (+ Checksum)

--- a/gui/src/App.jsx
+++ b/gui/src/App.jsx
@@ -10,9 +10,10 @@ import FooterBar from './components/FooterBar.jsx';
 
 export default function App() {
   const images = useStore((s) => s.images);
+  const activeId = useStore((s) => s.activeImageId);
   const project = useStore((s) => s.project);
   const theme = useStore((s) => s.prefs.theme || 'dark');
-  const activeImage = images[0];
+  const activeImage = images.find((img) => img.id === activeId);
   return (
     <div className="h-screen flex flex-col bg-bg-primary" data-theme={theme}>
       <TitleBar projectName={project?.title} />

--- a/gui/src/components/LeftSidebar.jsx
+++ b/gui/src/components/LeftSidebar.jsx
@@ -1,13 +1,19 @@
 import React from 'react';
+import { useStore } from '../store.js';
 
 // Seitenleiste mit Projektdateien und Historie
 export default function LeftSidebar({ images }) {
+  const setActive = useStore((s) => s.setActiveImageId);
   return (
     <div className="w-60 flex flex-col bg-bg-secondary text-white overflow-auto">
       <div className="p-2 font-semibold">Projekt-Dateien</div>
       <ul className="flex-1 px-2 space-y-2">
         {images.map((img) => (
-          <li key={img.id} className="neu p-1 text-xs flex items-center gap-2">
+          <li
+            key={img.id}
+            className="neu p-1 text-xs flex items-center gap-2 cursor-pointer"
+            onClick={() => setActive(img.id)}
+          >
             <img src={img.path} alt="thumb" className="w-10 h-10 object-cover" />
             <span>{img.id}</span>
           </li>

--- a/gui/src/components/RightInspector.jsx
+++ b/gui/src/components/RightInspector.jsx
@@ -8,15 +8,26 @@ const MODELS = ['lama', 'sd2_inpaint', 'revanimated'];
 export default function RightInspector() {
   const prefs = useStore((s) => s.prefs);
   const updatePrefs = useStore((s) => s.updatePrefs);
+  const images = useStore((s) => s.images);
+  const activeId = useStore((s) => s.activeImageId);
+  const activeImg = images.find((img) => img.id === activeId);
 
   function handleModelChange(e) {
     updatePrefs({ inpaintModel: e.target.value });
   }
 
+  const imageProps = activeImg ? (
+    <div className="p-2 text-xs" data-testid="img-props">
+      <div className="mb-2">Bild-ID: {activeImg.id}</div>
+      <div className="break-all">Pfad: {activeImg.path}</div>
+    </div>
+  ) : null;
+
   return (
     <div className="w-72 bg-bg-secondary text-white overflow-auto">
       <div className="p-2 font-semibold">Eigenschaften</div>
-      <div className="p-2 text-xs">
+      {imageProps}
+      <div className="p-2 text-xs" data-testid="model-select">
         <label className="block mb-2">Inpainting-Modell</label>
         <select
           aria-label="Inpainting-Modell auswählen"

--- a/gui/src/renderer/components/SidePanel.tsx
+++ b/gui/src/renderer/components/SidePanel.tsx
@@ -1,10 +1,23 @@
 import React from 'react';
+import { useGalleryStore } from '../stores/useGalleryStore';
 
 // Rechte Seitenleiste mit Accordions
 export default function SidePanel() {
+  const images = useGalleryStore((s) => s.images);
+  const selectedId = useGalleryStore((s) => s.selectedId);
+  const active = images.find((img) => img.id === selectedId);
+
   return (
     <aside className="w-72 bg-gray-800 text-white p-2 overflow-auto">
-      SidePanel
+      <div className="font-semibold mb-2">Eigenschaften</div>
+      {active ? (
+        <div data-testid="img-props" className="text-xs">
+          <div className="mb-1">ID: {active.id}</div>
+          <div className="break-all">{active.name}</div>
+        </div>
+      ) : (
+        <div className="text-xs text-gray-400">Kein Bild ausgewählt</div>
+      )}
     </aside>
   );
 }

--- a/gui/src/store.js
+++ b/gui/src/store.js
@@ -4,10 +4,16 @@ import create from 'zustand';
 export const useStore = create((set) => ({
   project: null,
   images: [],
+  // aktuell ausgewähltes Bild
+  activeImageId: null,
   // Voreinstellungen inklusive Design-Theme
   prefs: { theme: 'dark' },
   setProject: (p) => set({ project: p }),
-  setImages: (imgs) => set({ images: imgs }),
+  // ersetzt die Bildliste und wählt das erste Bild aus
+  setImages: (imgs) =>
+    set({ images: imgs, activeImageId: imgs[0] ? imgs[0].id : null }),
+  // setzt das aktive Bild explizit
+  setActiveImageId: (id) => set({ activeImageId: id }),
   // Aktualisiert einzelne Einstellungen
   updatePrefs: (patch) =>
     set((state) => ({ prefs: { ...state.prefs, ...patch } })),

--- a/gui/tests/e2e/sidepanel.spec.ts
+++ b/gui/tests/e2e/sidepanel.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+test('SidePanel zeigt Bild-Eigenschaften an', async ({ page }) => {
+  await page.goto('http://localhost:5173');
+  await page.evaluate(() => {
+    window.dialogs = { openImages: async () => ['/tmp/test.png'] } as any;
+  });
+  await page.keyboard.press('Control+O');
+  // Thumbnail auswählen
+  await page.locator('button >> nth=0').click();
+  await expect(page.getByTestId('img-props')).toBeVisible();
+});


### PR DESCRIPTION
## Zusammenfassung
- SidePanel zeigt nun Bildinformationen an
- entsprechende Zustandslogik in `useStore`
- README und Changelog aktualisiert
- neuer End-to-end-Test `sidepanel.spec.ts`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bcee0c5508327a310c31bdd00b38c