### PR TITLE
Fix weißes Fenster ohne Build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -692,3 +692,10 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 ### Behoben
 - Build-Fehler durch fehlenden `createIPCClient`-Export behoben.
 
+## [1.8.30] - 2025-10-21
+### Behoben
+- Fehlt der `dist`-Ordner, zeigt die Anwendung nun einen Hinweis statt eines
+  weißen Fensters.
+### Geändert
+- README erläutert diesen Hinweis und wie der Build nachgeholt werden kann.
+

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ python start.py          # erstellt venv, lädt Modelle, baut GUI
 python start.py --dev    # Hot‑Reload für Front‑ und Backend
 ```
 
+Sollte nach dem Start nur ein weißes Fenster erscheinen, fehlt meist der
+Frontend-Build. Führe in diesem Fall `python start.py` oder alternativ
+`npm run build` im Ordner `gui/` aus.
+
 ### Sprache umschalten
 
 Oben rechts in der GUI kannst du zwischen **DE** und **EN** wählen. Die zugehörigen

--- a/gui/electron/main.js
+++ b/gui/electron/main.js
@@ -57,7 +57,16 @@ function createWindow() {
       }
     });
   } else {
-    mainWindow.loadFile(path.join(__dirname, '../dist/index.html'));
+    // Im Produktivmodus die gebaute Oberflaeche laden
+    const dist = path.join(__dirname, '../dist/index.html');
+    if (fs.existsSync(dist)) {
+      mainWindow.loadFile(dist);
+    } else {
+      // Falls der Build fehlt, bekommt der Nutzer einen Hinweis
+      const msg = `<!doctype html><h1>GUI nicht gefunden</h1>
+      <p>Bitte "npm run build" oder "python start.py" ausführen.</p>`;
+      mainWindow.loadURL('data:text/html,' + encodeURIComponent(msg));
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- zeige Hinweis, wenn der GUI-Build fehlt
- dokumentiere die Fehlermeldung im README
- CHANGELOG ergänzt

## Testing
- `pytest tests/test_logging.py::test_logging_and_report -vv`

------
https://chatgpt.com/codex/tasks/task_e_687bd8d338a0832786064c2d53285369