### PR TITLE
Add start.cmd for double-click usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -705,3 +705,9 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 - Skript `scripts/repair_gui.py` erstellt den Frontend-Build automatisch nach.
 ### Geändert
 - README erwähnt das neue Reparatur-Skript.
+
+## [1.8.32] - 2025-10-23
+### Hinzugefügt
+- `start.cmd` ermöglicht den Start per Doppelklick unter Windows.
+### Geändert
+- README und Handbuch beschreiben das neue Skript.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ python start.py          # erstellt venv, lädt Modelle, baut GUI
 python start.py --dev    # Hot‑Reload für Front‑ und Backend
 ```
 
+Unter Windows kannst du das Programm auch bequem per Doppelklick starten.
+Nutze dazu entweder direkt `start.py` oder das neue Skript `start.cmd`.
+
 Sollte nach dem Start nur ein weißes Fenster erscheinen, fehlt meist der
 Frontend-Build. Führe in diesem Fall `python start.py` oder alternativ
 `npm run build` im Ordner `gui/` aus. Komfortabler geht es mit dem Skript

--- a/docs/handbuch.md
+++ b/docs/handbuch.md
@@ -12,6 +12,8 @@ Dieses Handbuch dient als Einstieg in die Nutzung der Applikation. Es fasst die 
    ```bash
    python start.py
    ```
+   Unter Windows kannst du dazu einfach `start.py` oder das beiliegende
+   `start.cmd` doppelklicken.
 
 ## Grundlegender Workflow
 

--- a/start.cmd
+++ b/start.cmd
@@ -1,0 +1,5 @@
+@echo off
+REM Startet DeZensur ueber start.py
+pushd %~dp0
+python start.py %*
+popd


### PR DESCRIPTION
## Summary
- add `start.cmd` for Windows to run `start.py` via double click
- document Windows start option in README and docs/handbuch
- update changelog with new script entry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bed2e2bc88327aa74622f2ee9ee66