### PR TITLE
Fix skip npm flag handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -711,3 +711,9 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 - `start.cmd` ermöglicht den Start per Doppelklick unter Windows.
 ### Geändert
 - README und Handbuch beschreiben das neue Skript.
+
+## [1.8.33] - 2025-10-24
+### Geändert
+- `start.py` verweigert `SKIP_NPM_INSTALL` außerhalb von CI und warnt den Nutzer.
+### Hinzugefügt
+- Tests `test_should_skip_npm_install_*` und README-TODO aktualisiert.

--- a/README.md
+++ b/README.md
@@ -409,9 +409,9 @@ _Nur Punkte, die **noch offen** sind – als kopier- & abhakbare Markdown-Checkb
   - **Tests:** `tests/models/test_checksum.py`.
 
 #### 3️⃣ Dev-Scripts & CI
-- [ ] **start.py überspringt _npm install_** wenn `SKIP_NPM_INSTALL` gesetzt  
-  - **Fix:** Flag nur für CI erlauben; Warnung im Terminal.  
-  - **Tests:** `tests/scripts/test_start_skip.py`.
+- [x] **start.py überspringt _npm install_** wenn `SKIP_NPM_INSTALL` gesetzt
+  - **Fix:** Flag nur für CI erlauben; Warnung im Terminal.
+  - **Tests:** `tests/test_start.py::test_should_skip_npm_install_*`.
 
 - [ ] **Code-Signing Pipeline**  
   - Windows EXE unsigniert → SmartScreen-Warnung.  

--- a/start.py
+++ b/start.py
@@ -242,6 +242,17 @@ def run_npm_audit() -> None:
         )
 
 
+def should_skip_npm_install(argv: list[str] | None = None) -> bool:
+    """Entscheidet, ob das NPM-Install ausgelassen werden darf."""
+
+    argv = argv or sys.argv
+    skip_requested = os.environ.get("SKIP_NPM_INSTALL") or "--skip-npm" in argv
+    if skip_requested and not os.environ.get("CI"):
+        print("Warnung: SKIP_NPM_INSTALL ist nur in CI erlaubt und wird ignoriert.")
+        return False
+    return bool(skip_requested)
+
+
 def ensure_gui_build() -> None:
     """Baut das Frontend, falls noch keine Dist-Dateien vorhanden sind."""
 
@@ -376,9 +387,8 @@ def main() -> None:
     package_json = Path("gui/package.json")
     node_modules = Path("gui/node_modules")
 
-    # Installation der NPM-Pakete kann über die Umgebungsvariable
-    # "SKIP_NPM_INSTALL" oder den Parameter "--skip-npm" übersprungen werden.
-    skip_npm = os.environ.get("SKIP_NPM_INSTALL") or "--skip-npm" in sys.argv
+    # Prüfen, ob npm-Install übersprungen werden soll
+    skip_npm = should_skip_npm_install()
 
     # NPM-Pakete installieren, falls erforderlich und nicht übersprungen
     if not skip_npm and (

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -84,3 +84,17 @@ def test_ensure_gui_build(monkeypatch, tmp_path):
         with mock.patch("tkinter.Tk"), mock.patch("tkinter.messagebox.showerror"):
             start.ensure_gui_build()
         m_run.assert_not_called()
+
+
+def test_should_skip_npm_install_ci(monkeypatch):
+    monkeypatch.setenv("SKIP_NPM_INSTALL", "1")
+    monkeypatch.setenv("CI", "true")
+    assert start.should_skip_npm_install(["--skip-npm"]) is True
+
+
+def test_should_skip_npm_install_local(monkeypatch, capsys):
+    monkeypatch.setenv("SKIP_NPM_INSTALL", "1")
+    monkeypatch.delenv("CI", raising=False)
+    assert start.should_skip_npm_install(["--skip-npm"]) is False
+    out = capsys.readouterr().out
+    assert "nur in CI erlaubt" in out


### PR DESCRIPTION
## Summary
- block usage of `SKIP_NPM_INSTALL` outside CI and warn users
- document the change and mark TODO as done
- add unit tests for the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bfab16dd08327b4a484317c90d365