### PR TITLE
Fix electron-reload version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -748,3 +748,10 @@ Alle Änderungen werden in diesem Dokument festgehalten.
 ### Behoben
 - Download des Modells `anime_censor_detection` schlägt nicht mehr wegen
   falscher Prüfsumme fehl. Die Prüfsumme wird nun ignoriert.
+
+## [1.8.38] - 2025-10-29
+### Behoben
+- `npm install` schlug fehl, weil `electron-reload` in Version 2.0.2 nicht
+  verfügbar ist. Die Abhängigkeit wurde daher auf Version 1.5.0 gesetzt.
+### Geändert
+- README und `package.json` führen die angepasste Version auf.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Eine kompakte Referenz für LLM‑Agents ohne Internet‑Zugriff.
 
 | Paket | Version | Grund |
 |-------|---------|-------|
-| `electron-reload` | `2.0.2` (Fallback 2.0.0) | kompatibel mit Electron 28 |
+| `electron-reload` | `1.5.0` (Fallback 2.0.0) | kompatibel mit Electron 28 |
 | `electron` | `28.2.0` | stable Release |
 | `electron-trpc` | `0.7.1` | neuere Versionen nicht im Registry |
 | `react-konva` | `19.0.7` | 19.0.24 nie veröffentlicht |
@@ -376,7 +376,7 @@ _Nur Punkte, die **noch offen** sind – als kopier- & abhakbare Markdown-Checkb
   - **Tests:** Storybook Screenshot-Diff.
 
 - [x] **Incompatible NPM-Versions**
-  - `electron-reload` ^1.5.0 → 2.0.2  
+  - `electron-reload` ^1.5.0 → 1.5.0
   - `electron-trpc` ^0.11.0 → 0.7.1 (letzte veröffentlichte)  
   - `react-konva` ^19.0.7 → **19.0.7** (Caret entfernen)  
   - `electron` “latest” → 28.2.x pinnen  

--- a/gui/package.json
+++ b/gui/package.json
@@ -28,7 +28,7 @@
     "react-dropzone": "^14.0.0",
     "react-router-dom": "^6.0.0",
     "concurrently": "^8.0.0",
-    "electron-reload": "2.0.2",
+    "electron-reload": "1.5.0",
     "konva": "^9.3.3",
     "react-konva": "19.0.7",
     "jest": "^29.0.0",


### PR DESCRIPTION
## Summary
- pin electron-reload to 1.5.0 since 2.0.2 is missing
- update README table and todo section accordingly
- document the change in CHANGELOG

## Testing
- `pytest --maxfail=1 -vv`

------
https://chatgpt.com/codex/tasks/task_e_687c1b4ba8348327bd5344c1f85ccdb5