### PR TITLE
Doc update: build hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -755,3 +755,8 @@ Alle Änderungen werden in diesem Dokument festgehalten.
   verfügbar ist. Die Abhängigkeit wurde daher auf Version 1.5.0 gesetzt.
 ### Geändert
 - README und `package.json` führen die angepasste Version auf.
+
+## [1.8.39] - 2025-10-30
+### Geändert
+- README ergänzt: `npm start` ohne vorangegangenen Build führt zu einer leeren
+  Oberfläche. Empfohlene Befehle sind `python start.py` oder `npm run build`.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Sollte nach dem Start nur ein weißes Fenster erscheinen, fehlt meist der
 Frontend-Build. Führe in diesem Fall `python start.py` oder alternativ
 `npm run build` im Ordner `gui/` aus. Komfortabler geht es mit dem Skript
 `python scripts/repair_gui.py`, das den Build automatisch nachholt.
+Rufe die GUI nicht direkt mit `npm start` auf, solange kein Build
+existiert – sonst bleibt das Fenster leer.
 
 ### Sprache umschalten
 


### PR DESCRIPTION
## Summary
- document that running `npm start` without prior build leaves the UI blank

## Testing
- `pytest -ra`

------
https://chatgpt.com/codex/tasks/task_e_687c1fd5ebac8327b9c98f80e1120ded