### PR TITLE
Fix weißes Fenster durch defekten GUI-Build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -809,3 +809,10 @@ Alle Ãnderungen werden in diesem Dokument festgehalten.
 ### Geändert
 - Repository erneut mit `isort .` formatiert; es waren keine Anpassungen nötig.
   Alle Tests laufen jetzt lokal durch.
+
+## [1.8.47] - 2025-11-07
+### Behoben
+- `start.py` erkennt nun beschädigte oder sehr kleine `gui/dist/index.html`
+  und baut die Oberfläche automatisch neu.
+### Geändert
+- README beschreibt den automatischen Neu-Build bei weißem Fenster.

--- a/README.md
+++ b/README.md
@@ -104,13 +104,13 @@ python start.py --force-build
 Unter Windows kannst du das Programm auch bequem per Doppelklick starten.
 Nutze dazu entweder direkt `start.py` oder das neue Skript `start.cmd`.
 
-Sollte nach dem Start nur ein weißes Fenster erscheinen, fehlt meist der
-Frontend-Build. Führe in diesem Fall `python start.py` oder alternativ
-`npm run build` im Ordner `gui/` aus. Komfortabler geht es mit dem Skript
-`python scripts/repair_gui.py`, das den Build automatisch nachholt. Mit
-`python start.py --force-build` lässt sich der Build ebenfalls erzwingen.
-Rufe die GUI nicht direkt mit `npm start` auf, solange kein Build
-existiert – sonst bleibt das Fenster leer.
+Sollte nach dem Start nur ein weißes Fenster erscheinen, fehlt oder
+beschädigt oft der Frontend‑Build. `start.py` erkennt solche Fälle nun und
+erstellt die Dateien automatisch neu. Alternativ kannst du jederzeit
+`python scripts/repair_gui.py` ausführen oder im Ordner `gui/` ein
+`npm run build` anstoßen. Mit `python start.py --force-build` lässt sich der
+Build ebenfalls erzwingen. Starte die GUI nicht direkt mit `npm start`, wenn
+kein Build vorhanden ist – sonst bleibt das Fenster leer.
 
 ### Sprache umschalten
 

--- a/start.py
+++ b/start.py
@@ -260,7 +260,8 @@ def ensure_gui_build(force: bool = False) -> None:
     """
 
     dist_index = project_root / "gui" / "dist" / "index.html"
-    if force or not dist_index.exists():
+    # Neu bauen, wenn die Datei fehlt oder verdächtig klein ist
+    if force or not dist_index.exists() or dist_index.stat().st_size < 1000:
         # Unter Windows kann das Electron-Build scheitern, wenn keine
         # Berechtigung zum Anlegen von Symlinks vorhanden ist. Durch Setzen
         # dieser Umgebungsvariable wird das Codesigning deaktiviert und der

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -83,6 +83,13 @@ def test_ensure_gui_build(monkeypatch, tmp_path):
     with mock.patch.object(start, "run") as m_run:
         with mock.patch("tkinter.Tk"), mock.patch("tkinter.messagebox.showerror"):
             start.ensure_gui_build()
+        m_run.assert_called_once()
+
+    # Ein korrekt gebautes Frontend wird nicht erneut erstellt
+    (dist / "index.html").write_text("x" * 2000)
+    with mock.patch.object(start, "run") as m_run:
+        with mock.patch("tkinter.Tk"), mock.patch("tkinter.messagebox.showerror"):
+            start.ensure_gui_build()
         m_run.assert_not_called()
 
     # Mit force=True sollte der Build erneut angestossen werden


### PR DESCRIPTION
## Zusammenfassung
- GUI-Build wird neu erzeugt, wenn `gui/dist/index.html` fehlt oder zu klein ist
- README ergänzt Hinweis auf automatischen Neu-Build
- CHANGELOG aktualisiert
- neuer Test für `ensure_gui_build`

## Testing
- `pytest tests/test_start.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687cd5e25c0883279912100e8049d615